### PR TITLE
fix(client): Fix mapping proxy error

### DIFF
--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -2,11 +2,11 @@ import json
 import logging
 import requests
 from collections import defaultdict
+from avro.schema import MappingProxyEncoder
 
 from schema_registry.client.errors import ClientError
 from schema_registry.client.load import loads
 from schema_registry.client import status, utils
-
 
 log = logging.getLogger(__name__)
 
@@ -174,7 +174,7 @@ class SchemaRegistryClient(requests.Session):
 
         url = "/".join([self.url, "subjects", subject, "versions"])
 
-        body = {"schema": json.dumps(avro_schema.to_json())}
+        body = {"schema": json.dumps(avro_schema.to_json(), cls=MappingProxyEncoder)}
 
         result, code = self.request(url, method="POST", body=body, headers=headers)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ __version__ = "0.3.0"
 with open("README.md") as readme_file:
     long_description = readme_file.read()
 
-requires = ["avro-python3", "fastavro", "requests>=2.22.0"]
+requires = ["avro-python3>=1.9", "fastavro", "requests>=2.22.0"]
 
 setup(
     name="python-schema-registry-client",


### PR DESCRIPTION
We recently had an issue with some complex schemas. Sounds like error is related to python `mappingproxy` binding. We applied the following change to fix the issue.

The problem could be related to this Python bug https://bugs.python.org/issue34858

# Actual Behavior

Some schemas with complex configuration could not be created due to JSON parsing error.

# Expected Behavior

Valid JSON schemas should be correctly decoded by python module to be forwarded to schema registry.

# Steps to Reproduce the Problem

The following code (called `app.py`) is used to register a complex schema:

```python
import avro
from schema_registry.client import SchemaRegistryClient

SCHEMA_REGISTRY_URL='http://kafka-schema-registry.dev'
SUBJECT = 'my_subject'

data = '''
{
  "type": "record",
  "name": "visit",
  "fields": [
    {
      "name": "metadata",
      "type": {
        "type": "record",
        "name": "metadata_record",
        "fields": [
          {
            "name": "timestamp",
            "type": {
              "type": "long",
              "logicalType": "timestamp-millis"
            }
          }
        ]
      }
    }
  ]
}
'''

schema = avro.schema.Parse(data)

client = SchemaRegistryClient(SCHEMA_REGISTRY_URL)
client.register(SUBJECT, schema)
```

Backtrace:

```bash
Traceback (most recent call last):
  File "app.py", line 36, in <module>
    client.register(SUBJECT, schema)
  File "/usr/local/lib/python3.7/site-packages/schema_registry/client/client.py", line 177, in register
    body = {"schema": json.dumps(avro_schema.to_json())}
  File "/usr/local/lib/python3.7/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type mappingproxy is not JSON serializable
```

For easier testing I created the following GIST: https://gist.github.com/vmercierfr/f1a85ea7a9d3c1188da7d0b3fdf19885

# Proposition

I would add `MappingProxyEncoder` JSON decoder provided by `avro.schema` library to JSON dumps method. So `mappingproxy` objects will be correctly processed.

Can you consider this PR?

Thanks.