### PR TITLE
docs: Fix a few typos in the Message Serializer python example that prevent it from running.

### DIFF
--- a/docs/serializer.md
+++ b/docs/serializer.md
@@ -8,11 +8,11 @@ Usage:
 
 ```python
 from schema_registry.client import SchemaRegistryClient, schema
-from schema_registry.serializer import MessageSerializer
+from schema_registry.serializers import MessageSerializer
 
 client = SchemaRegistryClient("http://127.0.0.1:8080")
 
-message_serielizer = MessageSerializer(client)
+message_serializer = MessageSerializer(client)
 
 # Let's imagine that we have the foillowing schema.
 avro_user_schema = schema.AvroSchema({
@@ -53,10 +53,9 @@ bad_record = {
 }
 
 message_serializer.encode_record_with_schema(
-    "user", user_schema, bad_record)
-
-# Exception!!
-TypeError: unsupported operand type(s) for <<: 'str' and 'int'
+    "user", avro_user_schema, bad_record)
+# results in an error:
+#   TypeError: unsupported operand type(s) for <<: 'str' and 'int'
 ```
 
 Class and Methods:


### PR DESCRIPTION
Thank you for writing and sharing this library. I was working through the usage example in Message Serializer documentation and encountered a few typos that prevent it from running all the way through. I've corrected them in this PR.

Errors that were fixed are below...

```
Traceback (most recent call last):
  File "example.py", line 2, in <module>
    from schema_registry.serializer import MessageSerializer
ModuleNotFoundError: No module named 'schema_registry.serializer'
```

```
Traceback (most recent call last):
  File "example.py", line 28, in <module>
    message_encoded = message_serializer.encode_record_with_schema(
NameError: name 'message_serializer' is not defined
```

```
Traceback (most recent call last):
  File "example.py", line 47, in <module>
    "user", user_schema, bad_record)
NameError: name 'user_schema' is not defined
```