### PR TITLE
Sets _force to True when parsing schemas

### DIFF
--- a/schema_registry/client/schema.py
+++ b/schema_registry/client/schema.py
@@ -7,7 +7,7 @@ class AvroSchema:
     def __init__(self, schema: str) -> None:
         if isinstance(schema, str):
             schema = json.loads(schema)
-        self.schema = fastavro.parse_schema(schema)
+        self.schema = fastavro.parse_schema(schema, _force=True)
         self.generate_hash()
 
     def generate_hash(self) -> None:


### PR DESCRIPTION
Since the serializer's encode with schema method causes
a register of the schema, the schema in the registry will
be updated with the special fastavro hint to signify that
fastavro has already parsed the schema. This can be problematic
in a distributed system since other Python fastavro consumers
will not actually have parsed the schema. This can trigger
a KeyError in fastavro because fastavro maintains a module
level dictionary of all the schemas it has parsed. This will fix #30.