### PR TITLE
Add a long_description_content_type in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     version=__version__,
     description="Python Rest Client to interact against Schema Registry Confluent Server to manage Avro Schemas",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     author="Marcos Schroh",
     author_email="schrohm@gmail.com",
     install_requires=requires,


### PR DESCRIPTION
Add a long_description_content_type according to [this guide](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata) so the ReadMe displays correctly on [Pypi](https://pypi.org/project/python-schema-registry-client/)