### PR TITLE
fix serialization of nested record

### DIFF
--- a/schema_registry/serializers/faust_serializer.py
+++ b/schema_registry/serializers/faust_serializer.py
@@ -55,10 +55,7 @@ def serializer_factory(
                 # str is also a sequence, need to make sure we don't iterate over it.
                 return item
             elif isinstance(item, Mapping):
-                return item.__class__({
-                    key: Serializer._clean_item(value)
-                    for key, value in item.items()
-                })
+                return item.__class__({key: Serializer._clean_item(value) for key, value in item.items()})
             elif isinstance(item, Sequence):
                 return item.__class__(Serializer._clean_item(value) for value in item)
             return item

--- a/schema_registry/serializers/faust_serializer.py
+++ b/schema_registry/serializers/faust_serializer.py
@@ -55,9 +55,9 @@ def serializer_factory(
                 # str is also a sequence, need to make sure we don't iterate over it.
                 return item
             elif isinstance(item, Mapping):
-                return item.__class__({key: Serializer._clean_item(value) for key, value in item.items()})
+                return type(item)({key: Serializer._clean_item(value) for key, value in item.items()})  # type: ignore
             elif isinstance(item, Sequence):
-                return item.__class__(Serializer._clean_item(value) for value in item)
+                return type(item)(Serializer._clean_item(value) for value in item)  # type: ignore
             return item
 
         @staticmethod

--- a/schema_registry/serializers/faust_serializer.py
+++ b/schema_registry/serializers/faust_serializer.py
@@ -1,4 +1,5 @@
 import typing
+from collections.abc import Mapping, Sequence
 
 from schema_registry.client import SchemaRegistryClient
 from schema_registry.client.schema import AvroSchema
@@ -47,6 +48,22 @@ def serializer_factory(
             return self.encode_record_with_schema(self.schema_subject, self.schema, payload)
 
         @staticmethod
+        def _clean_item(item: typing.Any) -> typing.Any:
+            if isinstance(item, Record):
+                return Serializer._clean_item(item.to_representation())
+            elif isinstance(item, str):
+                # str is also a sequence, need to make sure we don't iterate over it.
+                return item
+            elif isinstance(item, Mapping):
+                return item.__class__({
+                    key: Serializer._clean_item(value)
+                    for key, value in item.items()
+                })
+            elif isinstance(item, Sequence):
+                return item.__class__(Serializer._clean_item(value) for value in item)
+            return item
+
+        @staticmethod
         def clean_payload(payload: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
             """
             Try to clean payload retrieve by faust.Record.to_representation.
@@ -60,14 +77,7 @@ def serializer_factory(
             Returns:
                 dict that represents the clean payload
             """
-            return {
-                key: (
-                    Serializer.clean_payload(value.to_representation())  # type: ignore
-                    if isinstance(value, Record)
-                    else value
-                )
-                for key, value in payload.items()
-            }
+            return Serializer._clean_item(payload)
 
     return Serializer(schema_registry_client, schema_subject, schema)
 

--- a/tests/serializer/test_faust_serializer_clean_payload.py
+++ b/tests/serializer/test_faust_serializer_clean_payload.py
@@ -13,12 +13,9 @@ def test_simple_record(client, country_schema):
     schema_subject = "test-country"
     faust_serializer = serializer.FaustSerializer(client, schema_subject, country_schema)
 
-    result = {
-        '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
-        'item': 'test'
-    }
+    result = {"__faust": {"ns": "tests.serializer.test_faust_serializer_clean_payload.DummyRecord"}, "item": "test"}
 
-    dummy = DummyRecord('test')
+    dummy = DummyRecord("test")
     assert result == faust_serializer.clean_payload(dummy)
 
 
@@ -27,14 +24,11 @@ def test_nested_record(client, country_schema):
     faust_serializer = serializer.FaustSerializer(client, schema_subject, country_schema)
 
     result = {
-        '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
-        'item': {
-            '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
-            'item': 'test'
-        }
+        "__faust": {"ns": "tests.serializer.test_faust_serializer_clean_payload.DummyRecord"},
+        "item": {"__faust": {"ns": "tests.serializer.test_faust_serializer_clean_payload.DummyRecord"}, "item": "test"},
     }
 
-    dummy = DummyRecord(DummyRecord('test'))
+    dummy = DummyRecord(DummyRecord("test"))
     assert result == faust_serializer.clean_payload(dummy)
 
 
@@ -43,17 +37,14 @@ def test_list_of_records(client, country_schema):
     faust_serializer = serializer.FaustSerializer(client, schema_subject, country_schema)
 
     result = {
-        '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
-        'item': [{
-            '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
-            'item': 'test'
-        }, {
-            '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
-            'item': 'test'
-        }]
+        "__faust": {"ns": "tests.serializer.test_faust_serializer_clean_payload.DummyRecord"},
+        "item": [
+            {"__faust": {"ns": "tests.serializer.test_faust_serializer_clean_payload.DummyRecord"}, "item": "test"},
+            {"__faust": {"ns": "tests.serializer.test_faust_serializer_clean_payload.DummyRecord"}, "item": "test"},
+        ],
     }
 
-    dummy = DummyRecord([DummyRecord('test'), DummyRecord('test')])
+    dummy = DummyRecord([DummyRecord("test"), DummyRecord("test")])
     assert result == faust_serializer.clean_payload(dummy)
 
 
@@ -62,20 +53,18 @@ def test_map_of_records(client, country_schema):
     faust_serializer = serializer.FaustSerializer(client, schema_subject, country_schema)
 
     result = {
-        '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
-        'item': {
-            'key1': {
-                '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
-                'item': 'test'
-            }, 'key2': {
-                '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
-                'item': 'test'
-            }
-        }
+        "__faust": {"ns": "tests.serializer.test_faust_serializer_clean_payload.DummyRecord"},
+        "item": {
+            "key1": {
+                "__faust": {"ns": "tests.serializer.test_faust_serializer_clean_payload.DummyRecord"},
+                "item": "test",
+            },
+            "key2": {
+                "__faust": {"ns": "tests.serializer.test_faust_serializer_clean_payload.DummyRecord"},
+                "item": "test",
+            },
+        },
     }
 
-    dummy = DummyRecord({
-        'key1': DummyRecord('test'),
-        'key2': DummyRecord('test')
-    })
+    dummy = DummyRecord({"key1": DummyRecord("test"), "key2": DummyRecord("test")})
     assert result == faust_serializer.clean_payload(dummy)

--- a/tests/serializer/test_faust_serializer_clean_payload.py
+++ b/tests/serializer/test_faust_serializer_clean_payload.py
@@ -1,0 +1,81 @@
+import typing
+
+from faust import Record
+
+from schema_registry.serializers import faust_serializer as serializer
+
+
+class DummyRecord(Record):
+    item: typing.Any
+
+
+def test_simple_record(client, country_schema):
+    schema_subject = "test-country"
+    faust_serializer = serializer.FaustSerializer(client, schema_subject, country_schema)
+
+    result = {
+        '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
+        'item': 'test'
+    }
+
+    dummy = DummyRecord('test')
+    assert result == faust_serializer.clean_payload(dummy)
+
+
+def test_nested_record(client, country_schema):
+    schema_subject = "test-country"
+    faust_serializer = serializer.FaustSerializer(client, schema_subject, country_schema)
+
+    result = {
+        '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
+        'item': {
+            '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
+            'item': 'test'
+        }
+    }
+
+    dummy = DummyRecord(DummyRecord('test'))
+    assert result == faust_serializer.clean_payload(dummy)
+
+
+def test_list_of_records(client, country_schema):
+    schema_subject = "test-country"
+    faust_serializer = serializer.FaustSerializer(client, schema_subject, country_schema)
+
+    result = {
+        '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
+        'item': [{
+            '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
+            'item': 'test'
+        }, {
+            '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
+            'item': 'test'
+        }]
+    }
+
+    dummy = DummyRecord([DummyRecord('test'), DummyRecord('test')])
+    assert result == faust_serializer.clean_payload(dummy)
+
+
+def test_map_of_records(client, country_schema):
+    schema_subject = "test-country"
+    faust_serializer = serializer.FaustSerializer(client, schema_subject, country_schema)
+
+    result = {
+        '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
+        'item': {
+            'key1': {
+                '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
+                'item': 'test'
+            }, 'key2': {
+                '__faust': {'ns': 'tests.serializer.test_faust_serializer_clean_payload.DummyRecord'},
+                'item': 'test'
+            }
+        }
+    }
+
+    dummy = DummyRecord({
+        'key1': DummyRecord('test'),
+        'key2': DummyRecord('test')
+    })
+    assert result == faust_serializer.clean_payload(dummy)


### PR DESCRIPTION
Here is my proposal to fix: https://github.com/marcosschroh/python-schema-registry-client/issues/59

This should handle most of the cases (tuple, list, dict, collections.abc.Sequence, collections.abc.MutableSequence, collections.abc.Mapping, collections.abc.MutableMapping) ,
you mentioned handling `typing.Union` but I don't think we need to do anything to handle this case (it's more an annotation than a real python type).

Also it will not work with hashable type (like `set`) as `Record` aren't hashable.
