### PR TITLE
(fix) Fix client.register cache lookup

### DIFF
--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -223,7 +223,7 @@ class SchemaRegistryClient:
             int: schema_id
         """
         schemas_to_id = self.subject_to_schema_ids[subject]
-        schema_id = schemas_to_id.get(avro_schema.name)
+        schema_id = schemas_to_id.get(avro_schema)
 
         if schema_id is not None:
             return schema_id


### PR DESCRIPTION
The `SchemaRegistryClient.subject_to _schema_ids` is treated as a `Mapping[subject, Mapping[schema, schema_id]]`, but the lookup in `SchemaRegistryClient.register` is treated as a `Mapping[subject, Mapping[subject, schema_id]]` and so always misses. This results in a cached schema being registered multiple times.