### PR TITLE
Check if schema is registered under subject before trying to register it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2020-12-22
+
+### Fixed
+
+- Checks if Schema is already registered before trying to register. This allows
+  Schema Registry to be readonly in production environment, with only CI/CD
+  being allowed to make changes.
+
+## [1.7.1] - 2020-12-07
+
+### Fixed
+
+- [faust] extra now depends on [faust-streaming fork](https://github.com/faust-streaming/faust)
+
 ## [1.7.0] - 2020-10-17
 
 ### Added

--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -256,6 +256,16 @@ class SchemaRegistryClient(BaseClient):
         if schema_id is not None:
             return schema_id
 
+        # Check if schema is already registered. This should normally work even if
+        # the schema registry we're talking to is readonly, enabling a setup where
+        # only CI/CD can do changes to Schema Registry, and production code has readonly
+        # access
+
+        response = self.check_version(subject, avro_schema, headers=headers, timeout=timeout)
+
+        if response is not None:
+            return response.schema_id
+
         url, method = self.url_manager.url_for("register", subject=subject)
         body = {"schema": json.dumps(avro_schema.raw_schema)}
 
@@ -728,6 +738,16 @@ class AsyncSchemaRegistryClient(BaseClient):
 
         if schema_id is not None:
             return schema_id
+
+        # Check if schema is already registered. This should normally work even if
+        # the schema registry we're talking to is readonly, enabling a setup where
+        # only CI/CD can do changes to Schema Registry, and production code has readonly
+        # access
+
+        response = await self.check_version(subject, avro_schema, headers=headers, timeout=timeout)
+
+        if response is not None:
+            return response.schema_id
 
         url, method = self.url_manager.url_for("register", subject=subject)
         body = {"schema": json.dumps(avro_schema.raw_schema)}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 
 with open("README.md") as readme_file:
     long_description = readme_file.read()

--- a/tests/client/sync_client/test_schema_registration.py
+++ b/tests/client/sync_client/test_schema_registration.py
@@ -53,12 +53,27 @@ def test_dupe_register(client):
     subject = "test-basic-schema"
     schema_id = client.register(subject, parsed)
 
+    # Verify we had a check version call
+    client.assert_url_suffix(0, "/subjects/%s" % subject)
+    client.assert_method(0, "POST")
+    # Verify that we had a register call
+    client.assert_url_suffix(1, "/subjects/%s/versions" % subject)
+    client.assert_method(1, "POST")
+    assert len(client.request_calls) == 2
+
     assert schema_id > 0
     latest = client.get_schema(subject)
+
+    client.assert_url_suffix(2, "/subjects/%s/versions/latest" % subject)
+    client.assert_method(2, "GET")
+    assert len(client.request_calls) == 3
 
     # register again under same subject
     dupe_id = client.register(subject, parsed)
     assert schema_id == dupe_id
+
+    # Served from cache
+    assert len(client.request_calls) == 3
 
     dupe_latest = client.get_schema(subject)
     assert latest == dupe_latest


### PR DESCRIPTION
This enables the use case where schema registry write access is limited to CI/CD, and runtime access is readonly, at the cost of one extra request to the schema registry in the case where the schema is not registered.

This btw mimics the behaviour of Kafka Connect's Avro deserializer.