### PR TITLE
New function: get_schema_subject_versions

### DIFF
--- a/schema_registry/client/paths.py
+++ b/schema_registry/client/paths.py
@@ -9,6 +9,7 @@ paths = [
     ("get_schema", "subjects/{subject}/versions/{version}", "GET"),
     ("check_version", "subjects/{subject}", "POST"),
     ("get_by_id", "schemas/ids/{schema_id}", "GET"),
+    ("get_schema_subject_versions", "schemas/ids/{schema_id}/versions", "GET"),
     ("test_compatibility", "compatibility/subjects/{subject}/versions/{version}", "POST"),
     ("update_compatibility", "config/{subject}", "PUT"),
     ("get_compatibility", "config/{subject}", "GET"),

--- a/schema_registry/client/schema.py
+++ b/schema_registry/client/schema.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from schema_registry.client.utils import AVRO_SCHEMA_TYPE, JSON_SCHEMA_TYPE
 
+from dataclasses import dataclass
+
 import json
 import typing
 
@@ -154,3 +156,9 @@ class SchemaFactory:
             return AvroSchema(schema)
         else:
             raise ValueError(f"Unsupported schema type '{schema_type}'. Supported schemas are 'AVRO' and 'JSON'.")
+
+
+@dataclass
+class SubjectVersion(object):
+    subject: str
+    version: int

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ __version__ = "2.0.0"
 with open("README.md") as readme_file:
     long_description = readme_file.read()
 
-requires = ["fastavro>=1.4.4", "jsonschema>=3.2.0", "httpx>=0.14,<0.15", "aiofiles>=0.7.0",]
+requires = ["fastavro>=1.4.4", "jsonschema>=3.2.0", "httpx>=0.14,<0.15", "aiofiles>=0.7.0", "dataclasses>=0.8; python_version < '3.7'"]
 
 description = "Python Rest Client to interact against Schema Registry Confluent Server to manage Avro Schemas"
 

--- a/tests/client/async_client/test_schema_registration.py
+++ b/tests/client/async_client/test_schema_registration.py
@@ -20,6 +20,10 @@ async def test_avro_register(async_client):
     assert schema_id > 0
     assert len(async_client.id_to_schema) == 1
 
+    schema_versions = await async_client.get_schema_subject_versions(schema_id)
+    assert len(schema_versions) == 1
+    assert schema_versions[0].subject == "test-avro-basic-schema"
+
 
 @pytest.mark.asyncio
 async def test_avro_register_json_data(async_client, avro_deployment_schema):
@@ -53,6 +57,17 @@ async def test_avro_multi_subject_register(async_client):
     dupe_id = await async_client.register("test-avro-basic-schema-backup", parsed)
     assert schema_id == dupe_id
     assert len(async_client.id_to_schema) == 1
+
+    schema_versions = await async_client.get_schema_subject_versions(schema_id)
+    assert len(schema_versions) == 2
+    schema_versions.sort(key=lambda x: x.subject)
+    assert schema_versions[0].subject == "test-avro-basic-schema"
+    assert schema_versions[1].subject == "test-avro-basic-schema-backup"
+    # The schema version we get here has a tendency to vary with the
+    # number of times the schema has been soft-deleted, so only verifying
+    # it's an int and > 0
+    assert type(schema_versions[1].version) == int
+    assert schema_versions[1].version > 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Uses GET /schemas/ids/{schema_id}/versions to retrieve the
list of subject,version pairs a schema ID is registered under.

See https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--schemas-ids-int-%20id-versions