### PR TITLE
add support for python 3.7+ and latest httpx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ tags
 .pytest_cache/
 
 .ipython/
+
+# PyCharm
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.7
+ARG PYTHON_VERSION
+
+FROM python:${PYTHON_VERSION}
     
 RUN apt-get update && apt-get install -y netcat && apt-get autoremove -y
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fmarcosschroh%2Fpython-schema-registry-client%2Fbadge%3Fref%3Dmaster&style=flat)](https://actions-badge.atrox.dev/marcosschroh/python-schema-registry-client/goto?ref=master)
 [![GitHub license](https://img.shields.io/github/license/marcosschroh/python-schema-registry-client.svg)](https://github.com/marcosschroh/python-schema-registry-client/blob/master/LICENSE)
 [![codecov](https://codecov.io/gh/marcosschroh/python-schema-registry-client/branch/master/graph/badge.svg)](https://codecov.io/gh/marcosschroh/python-schema-registry-client)
-[![Python Version](https://img.shields.io/badge/python-3.6%20%7C%203.7-blue.svg)](https://img.shields.io/badge/python-3.6%20%7C%203.7-blue.svg)
+[![Python Version](https://img.shields.io/badge/python-3.7+-blue.svg)](https://img.shields.io/badge/python-3.7+-blue.svg)
 
 Python Rest Client to interact against [schema-registry](https://docs.confluent.io/current/schema-registry/index.html) confluent server to manage [Avro](https://docs.oracle.com/database/nosql-12.1.3.1/GettingStartedGuide/avroschemas.html) and [JSON](https://json-schema.org/) schemas resources.
 
 ## Requirements
 
-python 3.6+
+python 3.7+
 
 ## Installation
 
@@ -321,7 +321,7 @@ Also, could be a use case that we would like to have an Application only to admi
 Install the project and development utilities in edit mode:
 
 ```bash
-pip3 install -e ".[tests,docs,faust]
+pip3 install -e ".[tests,docs,faust]"
 ```
 
 The tests are run against the `Schema Server` using `docker compose`, so you will need
@@ -331,13 +331,26 @@ The tests are run against the `Schema Server` using `docker compose`, so you wil
 ./scripts/test
 ```
 
+You can run tests with arbitrary python version by:
+
+```bash
+./scripts/test --python-version 3.x
+```
+
+All additional args will be passed to pytest, for example:
+
+```bash
+./scripts/test ./tests/client/ --maxfail=1 
+```
+
 Run code linting:
 
 ```bash
 ./scripts/lint
 ```
 
-To perform tests using the python shell you can execute `docker-compose up` and the `schema registry server` will run on `http://127.0.0.1:8081`, the you can interact against it using the `SchemaRegistryClient`:
+To perform tests using the python shell you can execute `docker-compose up` and the `schema registry server` 
+will run on `http://127.0.0.1:8081`, then you can interact against it using the `SchemaRegistryClient`:
 
 ```python
 from schema_registry.client import SchemaRegistryClient, schema

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,8 @@ services:
       - ZOOKEEPER_CLIENT_PORT=32181
 
   kafka:
-    image: confluentinc/cp-kafka
+    # pinned due to https://github.com/confluentinc/kafka-images/issues/127
+    image: confluentinc/cp-kafka:7.0.0
     hostname: kafka
     container_name: kafka
     ports:

--- a/schema_registry/client/urls.py
+++ b/schema_registry/client/urls.py
@@ -7,7 +7,10 @@ class UrlManager:
     def __init__(self, base_url: str, paths: list) -> None:
         parsed_url = urllib.parse.urlparse(base_url)
 
-        assert parsed_url.scheme, f"The url does not have a schema, add one. For example http://{base_url}"
+        assert parsed_url.scheme in (
+            "http",
+            "https",
+        ), f"The url {base_url} has invalid schema. Use http or https. For example http://{base_url}"
 
         # this is the absolute url to the server
         # make sure that url ends with /

--- a/scripts/install
+++ b/scripts/install
@@ -14,4 +14,4 @@ else
     PIP="pip"
 fi
 
-"$PIP" install -e  ".[docs,tests,faust]" --no-use-pep517
+"$PIP" install --no-cache-dir -e  ".[docs,tests,faust]"

--- a/scripts/test
+++ b/scripts/test
@@ -2,9 +2,35 @@
 
 set -o errexit
 
-docker-compose build
+PYTHON_VERSION="3.10"
+
+ARGS=""
+while (( "$#" )); do
+  case "$1" in
+    --python-version)
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        PYTHON_VERSION=$2
+        shift 2
+      else
+        echo "Error: Argument for $1 is missing" >&2
+        exit 1
+      fi
+      ;;
+    *) # preserve other arguments
+      ARGS="$ARGS $1"
+      shift
+      ;;
+  esac
+done
+
+# set positional arguments in their proper place
+eval set -- "$ARGS"
+
+echo "Run tests using python" $PYTHON_VERSION
+docker-compose build --build-arg PYTHON_VERSION=$PYTHON_VERSION
 
 # run tests against schema registry server
 docker-compose run --rm \
     -e CODECOV_TOKEN=${CODECOV_TOKEN} \
-    schema-registry-client ./scripts/run_test ${1-"./tests"}
+    schema-registry-client ./scripts/run_test ${1-"./tests"} \
+|| docker-compose down

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,12 @@ with open("README.md") as readme_file:
     long_description = readme_file.read()
 
 
-requires = ["fastavro>=1.4.4", "jsonschema>=3.2.0", "httpx>=0.14,<0.18", "aiofiles>=0.7.0", "dataclasses>=0.8; python_version < '3.7'"]
+requires = [
+    "fastavro>=1.4.4",
+    "jsonschema>=3.2.0",
+    "httpx>=0.18.2",
+    "aiofiles>=0.7.0",
+]
 
 description = "Python Rest Client to interact against Schema Registry Confluent Server to manage Avro Schemas"
 
@@ -25,8 +30,13 @@ setup(
     author_email="schrohm@gmail.com",
     install_requires=requires,
     extras_require={
-        "faust": ["faust-streaming",],
-        "docs": ["mkdocs", "mkdocs-material",],
+        "faust": [
+            "faust-streaming",
+        ],
+        "docs": [
+            "mkdocs",
+            "mkdocs-material",
+        ],
         "tests": [
             "black",
             "autoflake",
@@ -40,19 +50,23 @@ setup(
             "codecov",
             "pytest-cov",
             "dataclasses-avroschema",
-            "pydantic"
+            "pydantic",
         ],
     },
     url="https://github.com/marcosschroh/python-schema-registry-client",
     download_url="https://pypi.org/project/python-schema-registry-client/#files",
-    packages=find_packages(exclude=("tests", "docs",)),
+    packages=find_packages(
+        exclude=(
+            "tests",
+            "docs",
+        )
+    ),
     include_package_data=True,
     license="MIT",
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development",

--- a/tests/client/sync_client/test_http_client.py
+++ b/tests/client/sync_client/test_http_client.py
@@ -3,7 +3,7 @@ from base64 import b64encode
 
 import httpx
 import pytest
-from httpx._client import UNSET
+from httpx import USE_CLIENT_DEFAULT
 
 from schema_registry.client import SchemaRegistryClient, schema, utils
 from tests import data_gen
@@ -81,7 +81,9 @@ def test_override_headers(client, avro_deployment_schema, mocker, response_klass
     prepare_headers = client.prepare_headers(body="1")
     prepare_headers["custom-serialization"] = utils.HEADER_AVRO
 
-    request_patch.assert_called_once_with("POST", mocker.ANY, headers=prepare_headers, json=mocker.ANY, timeout=UNSET)
+    request_patch.assert_called_once_with(
+        "POST", mocker.ANY, headers=prepare_headers, json=mocker.ANY, timeout=USE_CLIENT_DEFAULT
+    )
 
 
 def test_cert_path():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from collections import namedtuple
 import pytest
 import pydantic
 from dataclasses_avroschema import AvroModel, types
-from httpx._client import UNSET, TimeoutTypes, UnsetType
 
 from schema_registry.client import AsyncSchemaRegistryClient, SchemaRegistryClient, errors, schema, utils
 from schema_registry.serializers import (
@@ -16,6 +15,8 @@ from schema_registry.serializers import (
     AsyncJsonMessageSerializer,
     AsyncAvroMessageSerializer,
 )
+
+from httpx._client import TimeoutTypes, UseClientDefault, USE_CLIENT_DEFAULT
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ class RequestLoggingSchemaRegistryClient(SchemaRegistryClient, RequestLoggingAss
         method: str = "GET",
         body: dict = None,
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> tuple:
         self.request_calls.append(RequestArgs(url, method, body, headers, timeout))
         return super().request(url, method, body, headers=headers, timeout=timeout)
@@ -302,7 +303,7 @@ class RequestLoggingAsyncSchemaRegistryClient(AsyncSchemaRegistryClient, Request
         method: str = "GET",
         body: dict = None,
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> tuple:
         self.request_calls.append(RequestArgs(url, method, body, headers, timeout))
         return await super().request(url, method, body, headers=headers, timeout=timeout)


### PR DESCRIPTION
In this PR

Major changes
- Add support for python >=3.7
- Add support for httpx>=0.18.2

Minor changes
- Add arg `--python-version` to `scripts/test`
- Teardown after tests by `docker-compose down`

To satisfy latest httpx versions we have to replace UnsetType and UNSET with UseClientDefault, USE_CLIENT_DEFAULT , look at an [issue](https://github.com/encode/httpx/issues/1384) on it and [changelog for httpx=0.18.2](https://github.com/encode/httpx/pull/1690). Also after [httpx=0.16](https://github.com/encode/httpx/pull/1347) closed clients raise a runtime error if attempting to send a request. So we should create new session if the previous session was closed. It's much better to create session on startup and reuse it for all requests, but it is not in the scope of this PR
