### PR TITLE
Provide support newer versions of httpx

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -33,13 +33,13 @@ SchemaRegistryClient
 Get Schema for a given version. If version is `None`, try to resolve the latest schema
 
 ```python
-def get_schema(subject: str, version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> utils.SchemaVersion:
+def get_schema(subject: str, version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> utils.SchemaVersion:
     """
     Args:
         subject (str): subject name
         version (int, optional): version id. If is None, the latest schema is returned
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         utils.SchemaVersion (nametupled): (subject, schema_id, schema, version)
@@ -54,12 +54,12 @@ def get_schema(subject: str, version="latest", headers: dict = None, timeout: ty
 ### Get schema by `id`
 
 ```python
-def get_by_id(schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> typing.Union[client.schema.AvroSchema, client.schema.JsonSchema]:
+def get_by_id(schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> typing.Union[client.schema.AvroSchema, client.schema.JsonSchema]:
     """
     Args:
         schema_id (int): Schema Id
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         typing.Union[client.schema.AvroSchema, client.schema.JsonSchema]: Avro or JSON Record schema
@@ -69,13 +69,13 @@ def get_by_id(schema_id: int, headers: dict = None, timeout: typing.Union[Timeou
 ### Register a Schema
 
 ```python
-def register(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema], headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET, schema_type: typing.Union["AVRO", "JSON"]) -> int:
+def register(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema], headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT, schema_type: typing.Union["AVRO", "JSON"]) -> int:
     """
     Args:
         subject (str): subject name
         schema typing.Union[client.schema.AvroSchema, client.schema.JsonSchema, str]: Avro or JSON schema to be registered
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
         schema_type typing.Union["AVRO", "JSON"]: The type of schema to parse if `schema` is a string. Default "AVRO"
 
     Returns:
@@ -86,7 +86,7 @@ def register(subject: str, schema: typing.Union[client.schema.AvroSchema, client
 ### Get Subjects
 
 ```python
-def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> list:
+def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> list:
     """
     GET /subjects/(string: subject)
     Get list of all registered subjects in your Schema Registry.
@@ -94,7 +94,7 @@ def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes,
     Args:
         subject (str): subject name
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         list [str]: list of registered subjects.
@@ -104,12 +104,12 @@ def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes,
 ### Delete Schema
 
 ```python
-def delete_subject(subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> list:
+def delete_subject(subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> list:
     """
     Args:
         subject (str): subject name
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         list (int): versions of the schema deleted under this subject
@@ -119,13 +119,13 @@ def delete_subject(subject: str, headers: dict = None, timeout: typing.Union[Tim
 ### Check if a schema has already been registered under the specified subject
 
 ```python
-def check_version(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema], headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET, schema_type: typing.Union["AVRO", "JSON"]) -> dict:
+def check_version(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema], headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT, schema_type: typing.Union["AVRO", "JSON"]) -> dict:
     """
     Args:
         subject (str): subject name
         schema typing.Union[client.schema.AvroSchema, client.schema.JsonSchema, str]: Avro or JSON schema to be registered
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
         schema_type typing.Union["AVRO", "JSON"]: The type of schema to parse if `schema` is a string. Default "AVRO"
 
     Returns:
@@ -142,7 +142,7 @@ def check_version(subject: str, schema: typing.Union[client.schema.AvroSchema, c
 ### Get schema version under a specific subject
 
 ```python
-def get_versions(self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> list:
+def get_versions(self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> list:
     """
     GET subjects/{subject}/versions
     Get a list of versions registered under the specified subject.
@@ -150,7 +150,7 @@ def get_versions(self, subject: str, headers: dict = None, timeout: typing.Union
     Args:
         subject (str): subject name
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         list (str): version of the schema registered under this subject
@@ -160,7 +160,7 @@ def get_versions(self, subject: str, headers: dict = None, timeout: typing.Union
 ### Deletes a specific version of the schema registered under a subject
 
 ```python
-def delete_version(self, subject: str, version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET):
+def delete_version(self, subject: str, version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT):
     """
     DELETE /subjects/(string: subject)/versions/(versionId: version)
 
@@ -177,7 +177,7 @@ def delete_version(self, subject: str, version="latest", headers: dict = None, t
             Valid values for versionId are between [1,2^31-1] or the string "latest".
             "latest" deletes the last registered schema under the specified subject.
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         int: version of the schema deleted
@@ -188,7 +188,7 @@ def delete_version(self, subject: str, version="latest", headers: dict = None, t
 ### Test Compatibility
 
 ```python
-def test_compatibility(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema], version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET, schema_type: typing.Union["AVRO", "JSON"]):
+def test_compatibility(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema], version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT, schema_type: typing.Union["AVRO", "JSON"]):
     """
     By default the latest version is checked against.
 
@@ -196,7 +196,7 @@ def test_compatibility(subject: str, schema: typing.Union[client.schema.AvroSche
         subject (str): subject name
         schema typing.Union[client.schema.AvroSchema, client.schema.JsonSchema, str]: Avro or JSON schema to be registered
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
         schema_type typing.Union["AVRO", "JSON"]: The type of schema to parse if `schema` is a string. Default "AVRO"
 
     Returns:
@@ -207,14 +207,14 @@ def test_compatibility(subject: str, schema: typing.Union[client.schema.AvroSche
 ### Get Compatibility
 
 ```python
-def get_compatibility(subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> str:
+def get_compatibility(subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> str:
     """
     Get the current compatibility level for a subject.  Result will be one of:
 
     Args:
         subject (str): subject name
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         str: one of BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE,
@@ -229,7 +229,7 @@ def get_compatibility(subject: str, headers: dict = None, timeout: typing.Union[
 ### Update Compatibility
 
 ```python
-def update_compatibility(level: str, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> bool:
+def update_compatibility(level: str, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> bool:
     """
     Update the compatibility level for a subject.
     If subject is None, the compatibility level is global.
@@ -238,7 +238,7 @@ def update_compatibility(level: str, subject: str, headers: dict = None, timeout
         level (str): one of BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE,
             FULL, FULL_TRANSITIVE, NONE
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         bool: True if compatibility was updated
@@ -271,13 +271,13 @@ AsyncSchemaRegistryClient
 Get Schema for a given version. If version is `None`, try to resolve the latest schema
 
 ```python
-async def get_schema(subject: str, version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> utils.SchemaVersion:
+async def get_schema(subject: str, version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> utils.SchemaVersion:
     """
     Args:
         subject (str): subject name
         version (int, optional): version id. If is None, the latest schema is returned
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         utils.SchemaVersion (nametupled): (subject, schema_id, schema, version)
@@ -292,12 +292,12 @@ async def get_schema(subject: str, version="latest", headers: dict = None, timeo
 ### Get schema by `id`
 
 ```python
-async def get_by_id(schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> typing.Union[client.schema.AvroSchema, client.schema.JsonSchema]:
+async def get_by_id(schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> typing.Union[client.schema.AvroSchema, client.schema.JsonSchema]:
     """
     Args:
         schema_id (int): Schema Id
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         typing.Union[client.schema.AvroSchema, client.schema.JsonSchema]: Avro or JSON Record schema
@@ -307,13 +307,13 @@ async def get_by_id(schema_id: int, headers: dict = None, timeout: typing.Union[
 ### Register a Schema
 
 ```python
-async def register(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema] headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET, schema_type: typing.Union["AVRO", "JSON"]) -> int:
+async def register(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema] headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT, schema_type: typing.Union["AVRO", "JSON"]) -> int:
     """
     Args:
         subject (str): subject name
         schema typing.Union[client.schema.AvroSchema, client.schema.JsonSchema, str]: Avro or JSON schema to be registered
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
         schema_type typing.Union["AVRO", "JSON"]: The type of schema to parse if `schema` is a string. Default "AVRO"
 
     Returns:
@@ -324,7 +324,7 @@ async def register(subject: str, schema: typing.Union[client.schema.AvroSchema, 
 ### Get Subjects
 
 ```python
-async def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> list:
+async def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> list:
     """
     GET /subjects/(string: subject)
     Get list of all registered subjects in your Schema Registry.
@@ -332,7 +332,7 @@ async def get_subjects(self, headers: dict = None, timeout: typing.Union[Timeout
     Args:
         subject (str): subject name
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         list [str]: list of registered subjects.
@@ -342,12 +342,12 @@ async def get_subjects(self, headers: dict = None, timeout: typing.Union[Timeout
 ### Delete Schema
 
 ```python
-async def delete_subject(subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> list:
+async def delete_subject(subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> list:
     """
     Args:
         subject (str): subject name
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         list (int): versions of the schema deleted under this subject
@@ -357,13 +357,13 @@ async def delete_subject(subject: str, headers: dict = None, timeout: typing.Uni
 ### Check if a schema has already been registered under the specified subject
 
 ```python
-async def check_version(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema], headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET, schema_type: typing.Union["AVRO", "JSON"]) -> dict:
+async def check_version(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema], headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT, schema_type: typing.Union["AVRO", "JSON"]) -> dict:
     """
     Args:
         subject (str): subject name
         schema typing.Union[client.schema.AvroSchema, client.schema.JsonSchema, str]: Avro or JSON schema to be registered
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
         schema_type typing.Union["AVRO", "JSON"]: The type of schema to parse if `schema` is a string. Default "AVRO"
 
     Returns:
@@ -380,7 +380,7 @@ async def check_version(subject: str, schema: typing.Union[client.schema.AvroSch
 ### Get schema version under a specific subject
 
 ```python
-async def get_versions(self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> list:
+async def get_versions(self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> list:
     """
     GET subjects/{subject}/versions
     Get a list of versions registered under the specified subject.
@@ -388,7 +388,7 @@ async def get_versions(self, subject: str, headers: dict = None, timeout: typing
     Args:
         subject (str): subject name
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         list (str): version of the schema registered under this subject
@@ -398,7 +398,7 @@ async def get_versions(self, subject: str, headers: dict = None, timeout: typing
 ### Deletes a specific version of the schema registered under a subject
 
 ```python
-async def delete_version(self, subject: str, version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET):
+async def delete_version(self, subject: str, version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT):
     """
     DELETE /subjects/(string: subject)/versions/(versionId: version)
 
@@ -415,7 +415,7 @@ async def delete_version(self, subject: str, version="latest", headers: dict = N
             Valid values for versionId are between [1,2^31-1] or the string "latest".
             "latest" deletes the last registered schema under the specified subject.
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         int: version of the schema deleted
@@ -426,7 +426,7 @@ async def delete_version(self, subject: str, version="latest", headers: dict = N
 ### Test Compatibility
 
 ```python
-async def test_compatibility(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema], version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET, schema_type: typing.Union["AVRO", "JSON"]):
+async def test_compatibility(subject: str, schema: typing.Union[client.schema.AvroSchema, client.schema.JsonSchema], version="latest", headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT, schema_type: typing.Union["AVRO", "JSON"]):
     """
     By default the latest version is checked against.
 
@@ -434,7 +434,7 @@ async def test_compatibility(subject: str, schema: typing.Union[client.schema.Av
         subject (str): subject name
         schema typing.Union[client.schema.AvroSchema, client.schema.JsonSchema, str]: Avro or JSON schema to be registered
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
         schema_type typing.Union["AVRO", "JSON"]: The type of schema to parse if `schema` is a string. Default "AVRO"
 
     Returns:
@@ -445,14 +445,14 @@ async def test_compatibility(subject: str, schema: typing.Union[client.schema.Av
 ### Get Compatibility
 
 ```python
-async def get_compatibility(subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> str:
+async def get_compatibility(subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> str:
     """
     Get the current compatibility level for a subject.  Result will be one of:
 
     Args:
         subject (str): subject name
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         str: one of BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE,
@@ -467,7 +467,7 @@ async def get_compatibility(subject: str, headers: dict = None, timeout: typing.
 ### Update Compatibility
 
 ```python
-async def update_compatibility(level: str, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> bool:
+async def update_compatibility(level: str, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> bool:
     """
     Update the compatibility level for a subject.
     If subject is None, the compatibility level is global.
@@ -476,7 +476,7 @@ async def update_compatibility(level: str, subject: str, headers: dict = None, t
         level (str): one of BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE,
             FULL, FULL_TRANSITIVE, NONE
         headers (dict): Extra headers to add on the requests
-        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+        timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
     Returns:
         bool: True if compatibility was updated

--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -15,7 +15,6 @@ from schema_registry.client.paths import paths
 from schema_registry.client.schema import AvroSchema, BaseSchema, JsonSchema, SchemaFactory, SubjectVersion
 from schema_registry.client.urls import UrlManager
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -170,7 +169,6 @@ class BaseClient:
         with httpx.Client(**self.client_kwargs) as client:
             response = client.request(method, url, headers=_headers, json=body, timeout=timeout)
         return response
-
 
     def _get_client_kwargs(self) -> typing.Dict:
         verify = self.conf.get(utils.SSL_CA_LOCATION, False)

--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -1,4 +1,3 @@
-import abc
 import json
 import logging
 import typing
@@ -163,7 +162,7 @@ class BaseClient:
         body: dict = None,
         headers: dict = None,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-    ) -> httpx.Response:
+    ) -> typing.Union[tuple, httpx.Response, typing.Coroutine[typing.Any, typing.Any, typing.Any]]:
         _headers = self.prepare_headers(body=body, headers=headers)
         with httpx.Client(**self.client_kwargs) as client:
             response = client.request(method, url, headers=_headers, json=body, timeout=timeout)
@@ -263,7 +262,6 @@ class SchemaRegistryClient(BaseClient):
         # access
 
         response = self.check_version(subject, schema, headers=headers, timeout=timeout)
-
         if response is not None:
             return response.schema_id
 
@@ -271,7 +269,6 @@ class SchemaRegistryClient(BaseClient):
         body = {"schema": json.dumps(schema.raw_schema), "schemaType": schema.schema_type}
 
         result, code, *_ = self.request(url, method=method, body=body, headers=headers, timeout=timeout)
-
         msg = None
         if code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN):
             msg = "Unauthorized access"
@@ -290,7 +287,9 @@ class SchemaRegistryClient(BaseClient):
 
         return schema_id
 
-    def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> list:
+    def get_subjects(
+        self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+    ) -> list:
         """
         GET /subjects/(string: subject)
         Get list of all registered subjects in your Schema Registry.
@@ -298,7 +297,9 @@ class SchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                    Default USE_CLIENT_DEFAULT
+
 
         Returns:
             list [str]: list of registered subjects.
@@ -312,7 +313,10 @@ class SchemaRegistryClient(BaseClient):
         raise ClientError("Unable to get subjects", http_code=code, server_traceback=result)
 
     def delete_subject(
-        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+        self,
+        subject: str,
+        headers: dict = None,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> list:
         """
         DELETE /subjects/(string: subject)
@@ -323,7 +327,8 @@ class SchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+             Default USE_CLIENT_DEFAULT
 
         Returns:
             list (int): version of the schema deleted under this subject
@@ -339,7 +344,10 @@ class SchemaRegistryClient(BaseClient):
         raise ClientError("Unable to delete subject", http_code=code, server_traceback=result)
 
     def get_by_id(
-        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+        self,
+        schema_id: int,
+        headers: dict = None,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> typing.Optional[typing.Union[AvroSchema, JsonSchema]]:
         """
         GET /schemas/ids/{int: id}
@@ -348,7 +356,8 @@ class SchemaRegistryClient(BaseClient):
         Args:
             schema_id (int): Schema Id
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+            Default USE_CLIENT_DEFAULT
 
         Returns:
             typing.Union[client.schema.AvroSchema, client.schema.JsonSchema]: Avro or JSON Record schema
@@ -374,7 +383,10 @@ class SchemaRegistryClient(BaseClient):
         raise ClientError(f"Received bad schema (id {schema_id})", http_code=code, server_traceback=result)
 
     def get_schema_subject_versions(
-        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+        self,
+        schema_id: int,
+        headers: dict = None,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> typing.Optional[typing.List[SubjectVersion]]:
         """
         GET /schemas/ids/{int: id}/versions
@@ -383,7 +395,8 @@ class SchemaRegistryClient(BaseClient):
         Args:
             schema_id (int): Schema Id
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                    Default USE_CLIENT_DEFAULT
 
         Returns:
             typing.List[SubjectVersion]: List of Subject/Version pairs where Schema Id is registered
@@ -416,7 +429,8 @@ class SchemaRegistryClient(BaseClient):
             subject (str): subject name
             version (int, optional): version id. If is None, the latest schema is returned
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+             Default USE_CLIENT_DEFAULT
 
         Returns:
             SchemaVersion (nametupled): (subject, schema_id, schema, version)
@@ -451,7 +465,10 @@ class SchemaRegistryClient(BaseClient):
         return utils.SchemaVersion(subject, schema_id, schema, version)
 
     def get_versions(
-        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+        self,
+        subject: str,
+        headers: dict = None,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> list:
         """
         GET subjects/{subject}/versions
@@ -460,7 +477,8 @@ class SchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                Default USE_CLIENT_DEFAULT
 
         Returns:
             list (str): version of the schema registered under this subject
@@ -498,7 +516,8 @@ class SchemaRegistryClient(BaseClient):
                 Valid values for versionId are between [1,2^31-1] or the string "latest".
                 "latest" deletes the last registered schema under the specified subject.
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                    Default USE_CLIENT_DEFAULT
 
         Returns:
             int: version of the schema deleted
@@ -560,7 +579,6 @@ class SchemaRegistryClient(BaseClient):
 
         url, method = self.url_manager.url_for("check_version", subject=subject)
         body = {"schema": json.dumps(schema.raw_schema), "schemaType": schema.schema_type}
-
         result, code, *_ = self.request(url, method=method, body=body, headers=headers, timeout=timeout)
         if code == status.HTTP_404_NOT_FOUND:
             logger.info(f"Schema {schema.name} under subject {subject} not found: {code}")
@@ -638,7 +656,8 @@ class SchemaRegistryClient(BaseClient):
                 FULL, FULL_TRANSITIVE, NONE
             subject (str): Option subject
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                    Default USE_CLIENT_DEFAULT
 
         Returns:
             bool: True if compatibility was updated
@@ -660,7 +679,10 @@ class SchemaRegistryClient(BaseClient):
         raise ClientError(f"Unable to update level: {level}.", http_code=code, server_traceback=result)
 
     def get_compatibility(
-        self, subject: str = None, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+        self,
+        subject: str = None,
+        headers: dict = None,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> str:
         """
         Get the current compatibility level for a subject.
@@ -668,7 +690,8 @@ class SchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                    Default USE_CLIENT_DEFAULT
 
         Returns:
             str: one of BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE,
@@ -797,7 +820,9 @@ class AsyncSchemaRegistryClient(BaseClient):
 
         return schema_id
 
-    async def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> list:
+    async def get_subjects(
+        self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+    ) -> list:
         """
         GET /subjects/(string: subject)
         Get list of all registered subjects in your Schema Registry.
@@ -805,7 +830,8 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                    Default USE_CLIENT_DEFAULT
 
         Returns:
             list [str]: list of registered subjects.
@@ -819,7 +845,10 @@ class AsyncSchemaRegistryClient(BaseClient):
         raise ClientError("Unable to get subjects", http_code=code, server_traceback=result)
 
     async def delete_subject(
-        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+        self,
+        subject: str,
+        headers: dict = None,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> list:
         """
         DELETE /subjects/(string: subject)
@@ -830,7 +859,8 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                Default USE_CLIENT_DEFAULT
 
         Returns:
             list (int): version of the schema deleted under this subject
@@ -846,7 +876,10 @@ class AsyncSchemaRegistryClient(BaseClient):
         raise ClientError("Unable to delete subject", http_code=code, server_traceback=result)
 
     async def get_by_id(
-        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+        self,
+        schema_id: int,
+        headers: dict = None,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> typing.Optional[typing.Union[AvroSchema, JsonSchema]]:
         """
         GET /schemas/ids/{int: id}
@@ -855,7 +888,8 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             schema_id (int): Schema Id
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                Default USE_CLIENT_DEFAULT
 
         Returns:
             typing.Union[client.schema.AvroSchema, client.schema.JsonSchema]: Avro or JSON Record schema
@@ -893,7 +927,8 @@ class AsyncSchemaRegistryClient(BaseClient):
             subject (str): subject name
             version (int, optional): version id. If is None, the latest schema is returned
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                Default USE_CLIENT_DEFAULT
 
         Returns:
             SchemaVersion (nametupled): (subject, schema_id, schema, version)
@@ -929,7 +964,10 @@ class AsyncSchemaRegistryClient(BaseClient):
         return utils.SchemaVersion(subject, schema_id, schema, version)
 
     async def get_schema_subject_versions(
-        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+        self,
+        schema_id: int,
+        headers: dict = None,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> typing.Optional[typing.List[SubjectVersion]]:
         """
         GET /schemas/ids/{int: id}/versions
@@ -938,7 +976,8 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             schema_id (int): Schema Id
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                    Default USE_CLIENT_DEFAULT
 
         Returns:
             typing.List[SubjectVersion]: List of Subject/Version pairs where Schema Id is registered
@@ -958,7 +997,10 @@ class AsyncSchemaRegistryClient(BaseClient):
         raise ClientError(f"Received bad schema (id {schema_id})", http_code=code, server_traceback=result)
 
     async def get_versions(
-        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+        self,
+        subject: str,
+        headers: dict = None,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> list:
         """
         GET subjects/{subject}/versions
@@ -967,7 +1009,8 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                    Default USE_CLIENT_DEFAULT
 
         Returns:
             list (str): version of the schema registered under this subject
@@ -1005,7 +1048,8 @@ class AsyncSchemaRegistryClient(BaseClient):
                 Valid values for versionId are between [1,2^31-1] or the string "latest".
                 "latest" deletes the last registered schema under the specified subject.
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                    Default USE_CLIENT_DEFAULT
 
         Returns:
             int: version of the schema deleted
@@ -1146,7 +1190,8 @@ class AsyncSchemaRegistryClient(BaseClient):
                 FULL, FULL_TRANSITIVE, NONE
             subject (str): Option subject
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+            Default USE_CLIENT_DEFAULT
 
         Returns:
             bool: True if compatibility was updated
@@ -1168,7 +1213,10 @@ class AsyncSchemaRegistryClient(BaseClient):
         raise ClientError(f"Unable to update level: {level}.", http_code=code, server_traceback=result)
 
     async def get_compatibility(
-        self, subject: str = None, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
+        self,
+        subject: str = None,
+        headers: dict = None,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> str:
         """
         Get the current compatibility level for a subject.
@@ -1176,7 +1224,8 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests.
+                    Default USE_CLIENT_DEFAULT
 
         Returns:
             str: one of BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE,

--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from urllib.parse import urlparse
 
 import httpx
-from httpx._client import USE_CLIENT_DEFAULT as UNSET, TimeoutTypes, UseClientDefault as UnsetType
+from httpx._client import USE_CLIENT_DEFAULT, TimeoutTypes, UseClientDefault
 
 from schema_registry.client import status, utils
 from schema_registry.client.errors import ClientError
@@ -162,7 +162,7 @@ class BaseClient:
         method: str = "GET",
         body: dict = None,
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         _headers = self.prepare_headers(body=body, headers=headers)
         with httpx.Client(**self.client_kwargs) as client:
@@ -200,7 +200,7 @@ class SchemaRegistryClient(BaseClient):
         method: str = "GET",
         body: dict = None,
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> tuple:
         if method not in utils.VALID_METHODS:
             raise ClientError(f"Method {method} is invalid; valid methods include {utils.VALID_METHODS}")
@@ -219,7 +219,7 @@ class SchemaRegistryClient(BaseClient):
         subject: str,
         schema: typing.Union[BaseSchema, str],
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         schema_type: str = utils.AVRO_SCHEMA_TYPE,
     ) -> int:
         """
@@ -240,7 +240,7 @@ class SchemaRegistryClient(BaseClient):
             headers (dict):
                 Extra headers to add on the requests
             timeout (httpx._client.TimeoutTypes):
-                The timeout configuration to use when sending requests. Default UNSET
+                The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
             schema_type typing.Union["AVRO", "JSON"]:
                 The type of schema to parse if `schema` is a string. Default "AVRO"
 
@@ -290,7 +290,7 @@ class SchemaRegistryClient(BaseClient):
 
         return schema_id
 
-    def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> list:
+    def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> list:
         """
         GET /subjects/(string: subject)
         Get list of all registered subjects in your Schema Registry.
@@ -298,7 +298,7 @@ class SchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             list [str]: list of registered subjects.
@@ -312,7 +312,7 @@ class SchemaRegistryClient(BaseClient):
         raise ClientError("Unable to get subjects", http_code=code, server_traceback=result)
 
     def delete_subject(
-        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET
+        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
     ) -> list:
         """
         DELETE /subjects/(string: subject)
@@ -323,7 +323,7 @@ class SchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             list (int): version of the schema deleted under this subject
@@ -339,7 +339,7 @@ class SchemaRegistryClient(BaseClient):
         raise ClientError("Unable to delete subject", http_code=code, server_traceback=result)
 
     def get_by_id(
-        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET
+        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
     ) -> typing.Optional[typing.Union[AvroSchema, JsonSchema]]:
         """
         GET /schemas/ids/{int: id}
@@ -348,7 +348,7 @@ class SchemaRegistryClient(BaseClient):
         Args:
             schema_id (int): Schema Id
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             typing.Union[client.schema.AvroSchema, client.schema.JsonSchema]: Avro or JSON Record schema
@@ -374,7 +374,7 @@ class SchemaRegistryClient(BaseClient):
         raise ClientError(f"Received bad schema (id {schema_id})", http_code=code, server_traceback=result)
 
     def get_schema_subject_versions(
-        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET
+        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
     ) -> typing.Optional[typing.List[SubjectVersion]]:
         """
         GET /schemas/ids/{int: id}/versions
@@ -383,7 +383,7 @@ class SchemaRegistryClient(BaseClient):
         Args:
             schema_id (int): Schema Id
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             typing.List[SubjectVersion]: List of Subject/Version pairs where Schema Id is registered
@@ -406,7 +406,7 @@ class SchemaRegistryClient(BaseClient):
         subject: str,
         version: typing.Union[int, str] = "latest",
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> typing.Optional[utils.SchemaVersion]:
         """
         GET /subjects/(string: subject)/versions/(versionId: version)
@@ -416,7 +416,7 @@ class SchemaRegistryClient(BaseClient):
             subject (str): subject name
             version (int, optional): version id. If is None, the latest schema is returned
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             SchemaVersion (nametupled): (subject, schema_id, schema, version)
@@ -451,7 +451,7 @@ class SchemaRegistryClient(BaseClient):
         return utils.SchemaVersion(subject, schema_id, schema, version)
 
     def get_versions(
-        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET
+        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
     ) -> list:
         """
         GET subjects/{subject}/versions
@@ -460,7 +460,7 @@ class SchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             list (str): version of the schema registered under this subject
@@ -481,7 +481,7 @@ class SchemaRegistryClient(BaseClient):
         subject: str,
         version: typing.Union[int, str] = "latest",
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> typing.Optional[int]:
         """
         DELETE /subjects/(string: subject)/versions/(versionId: version)
@@ -498,7 +498,7 @@ class SchemaRegistryClient(BaseClient):
                 Valid values for versionId are between [1,2^31-1] or the string "latest".
                 "latest" deletes the last registered schema under the specified subject.
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             int: version of the schema deleted
@@ -520,7 +520,7 @@ class SchemaRegistryClient(BaseClient):
         subject: str,
         schema: typing.Union[BaseSchema, str],
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         schema_type: str = utils.AVRO_SCHEMA_TYPE,
     ) -> typing.Optional[utils.SchemaVersion]:
         """
@@ -537,7 +537,7 @@ class SchemaRegistryClient(BaseClient):
             headers (dict):
                 Extra headers to add on the requests
             timeout (httpx._client.TimeoutTypes):
-                The timeout configuration to use when sending requests. Default UNSET
+                The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
             schema_type typing.Union["AVRO", "JSON"]:
                 The type of schema to parse if `schema` is a string. Default "AVRO"
 
@@ -580,7 +580,7 @@ class SchemaRegistryClient(BaseClient):
         schema: typing.Union[AvroSchema, JsonSchema, str],
         version: typing.Union[int, str] = "latest",
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         schema_type: str = utils.AVRO_SCHEMA_TYPE,
     ) -> bool:
         """
@@ -596,7 +596,7 @@ class SchemaRegistryClient(BaseClient):
             headers (dict):
                 Extra headers to add on the requests
             timeout (httpx._client.TimeoutTypes):
-                The timeout configuration to use when sending requests. Default UNSET
+                The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
             schema_type typing.Union["AVRO", "JSON"]:
                 The type of schema to parse if `schema` is a string. Default "AVRO"
 
@@ -626,7 +626,7 @@ class SchemaRegistryClient(BaseClient):
         level: str,
         subject: str = None,
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> bool:
         """
         PUT /config/(string: subject)
@@ -638,7 +638,7 @@ class SchemaRegistryClient(BaseClient):
                 FULL, FULL_TRANSITIVE, NONE
             subject (str): Option subject
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             bool: True if compatibility was updated
@@ -660,7 +660,7 @@ class SchemaRegistryClient(BaseClient):
         raise ClientError(f"Unable to update level: {level}.", http_code=code, server_traceback=result)
 
     def get_compatibility(
-        self, subject: str = None, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET
+        self, subject: str = None, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
     ) -> str:
         """
         Get the current compatibility level for a subject.
@@ -668,7 +668,7 @@ class SchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             str: one of BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE,
@@ -706,7 +706,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         method: str = "GET",
         body: dict = None,
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> tuple:
         if method not in utils.VALID_METHODS:
             raise ClientError(f"Method {method} is invalid; valid methods include {utils.VALID_METHODS}")
@@ -725,7 +725,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         subject: str,
         schema: typing.Union[BaseSchema, str],
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         schema_type: str = utils.AVRO_SCHEMA_TYPE,
     ) -> int:
         """
@@ -747,7 +747,7 @@ class AsyncSchemaRegistryClient(BaseClient):
             headers (dict):
                 Extra headers to add on the requests
             timeout (httpx._client.TimeoutTypes):
-                The timeout configuration to use when sending requests. Default UNSET
+                The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
             schema_type typing.Union["AVRO", "JSON"]:
                 The type of schema to parse if `schema` is a string. Default "AVRO"
 
@@ -797,7 +797,7 @@ class AsyncSchemaRegistryClient(BaseClient):
 
         return schema_id
 
-    async def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET) -> list:
+    async def get_subjects(self, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT) -> list:
         """
         GET /subjects/(string: subject)
         Get list of all registered subjects in your Schema Registry.
@@ -805,7 +805,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             list [str]: list of registered subjects.
@@ -819,7 +819,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         raise ClientError("Unable to get subjects", http_code=code, server_traceback=result)
 
     async def delete_subject(
-        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET
+        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
     ) -> list:
         """
         DELETE /subjects/(string: subject)
@@ -830,7 +830,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             list (int): version of the schema deleted under this subject
@@ -846,7 +846,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         raise ClientError("Unable to delete subject", http_code=code, server_traceback=result)
 
     async def get_by_id(
-        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET
+        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
     ) -> typing.Optional[typing.Union[AvroSchema, JsonSchema]]:
         """
         GET /schemas/ids/{int: id}
@@ -855,7 +855,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             schema_id (int): Schema Id
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             typing.Union[client.schema.AvroSchema, client.schema.JsonSchema]: Avro or JSON Record schema
@@ -883,7 +883,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         subject: str,
         version: typing.Union[int, str] = "latest",
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> typing.Optional[utils.SchemaVersion]:
         """
         GET /subjects/(string: subject)/versions/(versionId: version)
@@ -893,7 +893,7 @@ class AsyncSchemaRegistryClient(BaseClient):
             subject (str): subject name
             version (int, optional): version id. If is None, the latest schema is returned
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             SchemaVersion (nametupled): (subject, schema_id, schema, version)
@@ -929,7 +929,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         return utils.SchemaVersion(subject, schema_id, schema, version)
 
     async def get_schema_subject_versions(
-        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET
+        self, schema_id: int, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
     ) -> typing.Optional[typing.List[SubjectVersion]]:
         """
         GET /schemas/ids/{int: id}/versions
@@ -938,7 +938,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             schema_id (int): Schema Id
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             typing.List[SubjectVersion]: List of Subject/Version pairs where Schema Id is registered
@@ -958,7 +958,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         raise ClientError(f"Received bad schema (id {schema_id})", http_code=code, server_traceback=result)
 
     async def get_versions(
-        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET
+        self, subject: str, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
     ) -> list:
         """
         GET subjects/{subject}/versions
@@ -967,7 +967,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             list (str): version of the schema registered under this subject
@@ -988,7 +988,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         subject: str,
         version: typing.Union[int, str] = "latest",
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> typing.Optional[int]:
         """
         DELETE /subjects/(string: subject)/versions/(versionId: version)
@@ -1005,7 +1005,7 @@ class AsyncSchemaRegistryClient(BaseClient):
                 Valid values for versionId are between [1,2^31-1] or the string "latest".
                 "latest" deletes the last registered schema under the specified subject.
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             int: version of the schema deleted
@@ -1027,7 +1027,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         subject: str,
         schema: typing.Union[BaseSchema, str],
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         schema_type: str = utils.AVRO_SCHEMA_TYPE,
     ) -> typing.Optional[utils.SchemaVersion]:
         """
@@ -1044,7 +1044,7 @@ class AsyncSchemaRegistryClient(BaseClient):
             headers (dict):
                 Extra headers to add on the requests
             timeout (httpx._client.TimeoutTypes):
-                The timeout configuration to use when sending requests. Default UNSET
+                The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
             schema_type typing.Union["AVRO", "JSON"]:
                 The type of schema to parse if `schema` is a string. Default "AVRO"
 
@@ -1087,7 +1087,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         schema: typing.Union[AvroSchema, JsonSchema, str],
         version: typing.Union[int, str] = "latest",
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         schema_type: str = utils.AVRO_SCHEMA_TYPE,
     ) -> bool:
         """
@@ -1103,7 +1103,7 @@ class AsyncSchemaRegistryClient(BaseClient):
             headers (dict):
                 Extra headers to add on the requests
             timeout (httpx._client.TimeoutTypes):
-                The timeout configuration to use when sending requests. Default UNSET
+                The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
             schema_type typing.Union["AVRO", "JSON"]:
                 The type of schema to parse if `schema` is a string. Default "AVRO"
 
@@ -1134,7 +1134,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         level: str,
         subject: str = None,
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> bool:
         """
         PUT /config/(string: subject)
@@ -1146,7 +1146,7 @@ class AsyncSchemaRegistryClient(BaseClient):
                 FULL, FULL_TRANSITIVE, NONE
             subject (str): Option subject
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             bool: True if compatibility was updated
@@ -1168,7 +1168,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         raise ClientError(f"Unable to update level: {level}.", http_code=code, server_traceback=result)
 
     async def get_compatibility(
-        self, subject: str = None, headers: dict = None, timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET
+        self, subject: str = None, headers: dict = None, timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT
     ) -> str:
         """
         Get the current compatibility level for a subject.
@@ -1176,7 +1176,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         Args:
             subject (str): subject name
             headers (dict): Extra headers to add on the requests
-            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default UNSET
+            timeout (httpx._client.TimeoutTypes): The timeout configuration to use when sending requests. Default USE_CLIENT_DEFAULT
 
         Returns:
             str: one of BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE,

--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import typing
+from abc import abstractmethod
 from collections import defaultdict
 from urllib.parse import urlparse
 
@@ -174,6 +175,7 @@ class BaseClient:
             if version:
                 self._add_to_cache(self.subject_to_schema_versions, subject, schema, version)
 
+    @abstractmethod
     def request(
         self,
         url: str,

--- a/schema_registry/client/schema.py
+++ b/schema_registry/client/schema.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
-from abc import ABC, abstractmethod
-from schema_registry.client.utils import AVRO_SCHEMA_TYPE, JSON_SCHEMA_TYPE
-
-from dataclasses import dataclass
 
 import json
 import typing
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
 import aiofiles
 import fastavro
 import jsonschema
+
+from schema_registry.client.utils import AVRO_SCHEMA_TYPE, JSON_SCHEMA_TYPE
 
 
 class BaseSchema(ABC):

--- a/schema_registry/client/schema.py
+++ b/schema_registry/client/schema.py
@@ -28,13 +28,11 @@ class BaseSchema(ABC):
     @abstractmethod
     def load(fp: str) -> BaseSchema:
         """Parse a schema from a file path"""
-        pass
 
     @staticmethod
     @abstractmethod
     async def async_load(fp: str) -> BaseSchema:
         """Parse a schema from a file path"""
-        pass
 
     @property
     @abstractmethod

--- a/schema_registry/client/urls.py
+++ b/schema_registry/client/urls.py
@@ -7,7 +7,9 @@ class UrlManager:
     def __init__(self, base_url: str, paths: list) -> None:
         parsed_url = urllib.parse.urlparse(base_url)
 
-        assert parsed_url.scheme, f"The url does not have a schema, add one. For example http://{base_url}"
+        assert all(
+            [parsed_url.scheme, parsed_url.netloc]
+        ), f"The url does not have a schema, add one. For example http://{base_url}"
 
         # this is the absolute url to the server
         # make sure that url ends with /

--- a/schema_registry/serializers/__init__.py
+++ b/schema_registry/serializers/__init__.py
@@ -1,6 +1,6 @@
-from schema_registry.serializers.message_serializer import AvroMessageSerializer  # noqa
-from schema_registry.serializers.message_serializer import JsonMessageSerializer  # noqa
-from schema_registry.serializers.message_serializer import MessageSerializer  # noqa
 from schema_registry.serializers.message_serializer import AsyncAvroMessageSerializer  # noqa
 from schema_registry.serializers.message_serializer import AsyncJsonMessageSerializer  # noqa
 from schema_registry.serializers.message_serializer import AsyncMessageSerializer  # noqa
+from schema_registry.serializers.message_serializer import AvroMessageSerializer  # noqa
+from schema_registry.serializers.message_serializer import JsonMessageSerializer  # noqa
+from schema_registry.serializers.message_serializer import MessageSerializer  # noqa

--- a/schema_registry/serializers/message_serializer.py
+++ b/schema_registry/serializers/message_serializer.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from fastavro import schemaless_reader, schemaless_writer
 from jsonschema import validate
 
-from schema_registry.client import SchemaRegistryClient, schema, utils, AsyncSchemaRegistryClient
+from schema_registry.client import AsyncSchemaRegistryClient, SchemaRegistryClient, schema, utils
 from schema_registry.client.errors import ClientError
 from schema_registry.client.schema import BaseSchema
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("README.md") as readme_file:
 requires = [
     "fastavro>=1.4.4",
     "jsonschema>=3.2.0",
-    "httpx>=0.18.2",
+    "httpx>=0.19.0",
     "aiofiles>=0.7.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md") as readme_file:
     long_description = readme_file.read()
 
 
-requires = ["fastavro>=1.4.4", "jsonschema>=3.2.0", "httpx>=0.14,<0.18", "aiofiles>=0.7.0", "dataclasses>=0.8; python_version < '3.7'"]
+requires = ["fastavro>=1.4.4", "jsonschema>=3.2.0", "httpx>=0.19.0,<0.21.0", "aiofiles>=0.7.0", "dataclasses>=0.8; python_version < '3.7'"]
 
 description = "Python Rest Client to interact against Schema Registry Confluent Server to manage Avro Schemas"
 

--- a/tests/client/async_client/test_http_client.py
+++ b/tests/client/async_client/test_http_client.py
@@ -40,7 +40,7 @@ async def test_override_headers(avro_deployment_schema, response_klass, async_mo
     extra_headers = {"custom-serialization": utils.HEADER_AVRO_JSON}
     async_client = AsyncSchemaRegistryClient(url=os.getenv("SCHEMA_REGISTRY_URL"), extra_headers=extra_headers)
 
-    *_, response = await async_client.request("https://example.com")
+    response = await async_client.request("https://example.com")
     assert response.request.headers.get("custom-serialization") == utils.HEADER_AVRO_JSON
 
     subject = "test"
@@ -98,7 +98,7 @@ async def test_basic_auth_url():
     userpass = b":".join((httpx._utils.to_bytes(username), httpx._utils.to_bytes(password)))
     token = b64encode(userpass).decode()
 
-    *_, response = await client.request("https://example.com")
+    response = await client.request("https://example.com")
     assert response.request.headers.get("Authorization") == f"Basic {token}"
 
 
@@ -117,7 +117,7 @@ async def test_basic_auth_user_info():
     userpass = b":".join((httpx._utils.to_bytes(username), httpx._utils.to_bytes(password)))
     token = b64encode(userpass).decode()
 
-    *_, response = await client.request("https://example.com")
+    response = await client.request("https://example.com")
     assert response.request.headers.get("Authorization") == f"Basic {token}"
 
 
@@ -138,7 +138,7 @@ async def test_basic_auth_sasl_inherit():
     userpass = b":".join((httpx._utils.to_bytes(username), httpx._utils.to_bytes(password)))
     token = b64encode(userpass).decode()
 
-    *_, response = await client.request("https://example.com")
+    response = await client.request("https://example.com")
     assert response.request.headers.get("Authorization") == f"Basic {token}"
 
 

--- a/tests/client/sync_client/test_http_client.py
+++ b/tests/client/sync_client/test_http_client.py
@@ -71,7 +71,7 @@ def test_override_headers(client, avro_deployment_schema, mocker, response_klass
     extra_headers = {"custom-serialization": utils.HEADER_AVRO_JSON}
     client = SchemaRegistryClient("https://127.0.0.1:65534", extra_headers=extra_headers)
 
-    *_, response = client.request("https://example.com")
+    response = client.request("https://example.com")
     assert response.request.headers.get("custom-serialization") == utils.HEADER_AVRO_JSON
 
     subject = "test"
@@ -132,7 +132,7 @@ def test_basic_auth_url():
     client = SchemaRegistryClient({"url": f"https://{username}:{password}@127.0.0.1:65534"})
     userpass = b":".join((httpx._utils.to_bytes(username), httpx._utils.to_bytes(password)))
     token = b64encode(userpass).decode()
-    *_, response = client.request("https://example.com")
+    response = client.request("https://example.com")
     assert response.request.headers.get("Authorization") == f"Basic {token}"
 
 
@@ -149,7 +149,7 @@ def test_basic_auth_user_info():
 
     userpass = b":".join((httpx._utils.to_bytes(username), httpx._utils.to_bytes(password)))
     token = b64encode(userpass).decode()
-    *_, response = client.request("https://example.com")
+    response = client.request("https://example.com")
     assert response.request.headers.get("Authorization") == f"Basic {token}"
 
 
@@ -168,7 +168,7 @@ def test_basic_auth_sasl_inherit():
 
     userpass = b":".join((httpx._utils.to_bytes(username), httpx._utils.to_bytes(password)))
     token = b64encode(userpass).decode()
-    *_, response = client.request("https://example.com")
+    response = client.request("https://example.com")
     assert response.request.headers.get("Authorization") == f"Basic {token}"
 
 

--- a/tests/client/sync_client/test_http_client.py
+++ b/tests/client/sync_client/test_http_client.py
@@ -83,7 +83,9 @@ def test_override_headers(client, avro_deployment_schema, mocker, response_klass
     prepare_headers = client.prepare_headers(body="1")
     prepare_headers["custom-serialization"] = utils.HEADER_AVRO
 
-    request_patch.assert_called_once_with("POST", mocker.ANY, headers=prepare_headers, json=mocker.ANY, timeout=USE_CLIENT_DEFAULT)
+    request_patch.assert_called_once_with(
+        "POST", mocker.ANY, headers=prepare_headers, json=mocker.ANY, timeout=USE_CLIENT_DEFAULT
+    )
 
 
 def test_cert_path():

--- a/tests/client/sync_client/test_http_client.py
+++ b/tests/client/sync_client/test_http_client.py
@@ -3,7 +3,7 @@ from base64 import b64encode
 
 import httpx
 import pytest
-from httpx._client import USE_CLIENT_DEFAULT as UNSET
+from httpx._client import USE_CLIENT_DEFAULT
 
 from schema_registry.client import SchemaRegistryClient, schema, utils
 from tests import data_gen
@@ -83,7 +83,7 @@ def test_override_headers(client, avro_deployment_schema, mocker, response_klass
     prepare_headers = client.prepare_headers(body="1")
     prepare_headers["custom-serialization"] = utils.HEADER_AVRO
 
-    request_patch.assert_called_once_with("POST", mocker.ANY, headers=prepare_headers, json=mocker.ANY, timeout=UNSET)
+    request_patch.assert_called_once_with("POST", mocker.ANY, headers=prepare_headers, json=mocker.ANY, timeout=USE_CLIENT_DEFAULT)
 
 
 def test_cert_path():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,17 +4,17 @@ import os
 import typing
 from collections import namedtuple
 
-import pytest
 import pydantic
+import pytest
 from dataclasses_avroschema import AvroModel, types
-from httpx._client import UNSET, TimeoutTypes, UnsetType
+from httpx._client import USE_CLIENT_DEFAULT as UNSET, TimeoutTypes, UseClientDefault as UnsetType
 
 from schema_registry.client import AsyncSchemaRegistryClient, SchemaRegistryClient, errors, schema, utils
 from schema_registry.serializers import (
+    AsyncAvroMessageSerializer,
+    AsyncJsonMessageSerializer,
     AvroMessageSerializer,
     JsonMessageSerializer,
-    AsyncJsonMessageSerializer,
-    AsyncAvroMessageSerializer,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 import pydantic
 import pytest
 from dataclasses_avroschema import AvroModel, types
-from httpx._client import USE_CLIENT_DEFAULT as UNSET, TimeoutTypes, UseClientDefault as UnsetType
+from httpx._client import USE_CLIENT_DEFAULT, TimeoutTypes, UseClientDefault
 
 from schema_registry.client import AsyncSchemaRegistryClient, SchemaRegistryClient, errors, schema, utils
 from schema_registry.serializers import (
@@ -139,7 +139,7 @@ class RequestLoggingSchemaRegistryClient(SchemaRegistryClient, RequestLoggingAss
         method: str = "GET",
         body: dict = None,
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> tuple:
         self.request_calls.append(RequestArgs(url, method, body, headers, timeout))
         return super().request(url, method, body, headers=headers, timeout=timeout)
@@ -302,7 +302,7 @@ class RequestLoggingAsyncSchemaRegistryClient(AsyncSchemaRegistryClient, Request
         method: str = "GET",
         body: dict = None,
         headers: dict = None,
-        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
+        timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> tuple:
         self.request_calls.append(RequestArgs(url, method, body, headers, timeout))
         return await super().request(url, method, body, headers=headers, timeout=timeout)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 import pydantic
 import pytest
 from dataclasses_avroschema import AvroModel, types
+from httpx._client import USE_CLIENT_DEFAULT, TimeoutTypes, UseClientDefault
 
 from schema_registry.client import AsyncSchemaRegistryClient, SchemaRegistryClient, errors, schema, utils
 from schema_registry.serializers import (
@@ -15,8 +16,6 @@ from schema_registry.serializers import (
     AvroMessageSerializer,
     JsonMessageSerializer,
 )
-
-from httpx._client import TimeoutTypes, UseClientDefault, USE_CLIENT_DEFAULT
 
 logger = logging.getLogger(__name__)
 

--- a/tests/serializer/test_async_message_serializer.py
+++ b/tests/serializer/test_async_message_serializer.py
@@ -1,7 +1,7 @@
 import struct
 
-import pytest
 import jsonschema
+import pytest
 
 from schema_registry.client import schema
 from tests import data_gen

--- a/tests/serializer/test_faust_serializer.py
+++ b/tests/serializer/test_faust_serializer.py
@@ -5,7 +5,7 @@ import pydantic
 from dataclasses_avroschema import AvroModel
 
 from schema_registry.client import schema
-from schema_registry.serializers import faust as serializer, AvroMessageSerializer, JsonMessageSerializer
+from schema_registry.serializers import AvroMessageSerializer, JsonMessageSerializer, faust as serializer
 from tests import data_gen
 
 

--- a/tests/serializer/test_message_serializer.py
+++ b/tests/serializer/test_message_serializer.py
@@ -1,7 +1,7 @@
 import struct
 
-import pytest
 import jsonschema
+import pytest
 
 from schema_registry.client import schema
 from tests import data_gen


### PR DESCRIPTION
I made this PR for two reasons. 

-  With time, if we want to make this library adoptable for newer services, we need to evolve it alongside its dependencies. It's currently not compatible with the latest version of `httpx`. From `0.19.0` upward.


- Secondly, Httpx made some updates to newer versions of httpx. These updates include the efficient use of network resources. They [recommend using http Client as a context manager ](https://www.python-httpx.org/advanced/)as it ensures connections are properly cleaned up when leaving the “with” block.  
