### PR TITLE
Fix schema getters when fetching JSON schemas without cached results

### DIFF
--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -105,6 +105,7 @@ class BaseClient:
     def _schema_from_result(result: dict) -> typing.Union[JsonSchema, AvroSchema]:
         schema = result.get("schema")
         schema_type = result.get("schemaType", utils.AVRO_SCHEMA_TYPE)
+        return SchemaFactory.create_schema(schema, schema_type)
 
     def _configure_auth(self) -> typing.Tuple[str, str]:
         # Check first if the credentials are sent in Auth
@@ -429,6 +430,7 @@ class SchemaRegistryClient(BaseClient):
             logger.info(f"Schema {schema_id} not found: {code}")
             return None
         elif status.is_success(code):
+            print(result)
             schema = self._schema_from_result(result)
             self._cache_schema(schema, schema_id)
             return schema
@@ -986,6 +988,7 @@ class AsyncSchemaRegistryClient(BaseClient):
             logger.info(f"Schema {schema_id} not found: {code}")
             return None
         elif status.is_success(code):
+            print(result)
             schema = self._schema_from_result(result)
             self._cache_schema(schema, schema_id)
             return result

--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -430,7 +430,6 @@ class SchemaRegistryClient(BaseClient):
             logger.info(f"Schema {schema_id} not found: {code}")
             return None
         elif status.is_success(code):
-            print(result)
             schema = self._schema_from_result(result)
             self._cache_schema(schema, schema_id)
             return schema
@@ -988,7 +987,6 @@ class AsyncSchemaRegistryClient(BaseClient):
             logger.info(f"Schema {schema_id} not found: {code}")
             return None
         elif status.is_success(code):
-            print(result)
             schema = self._schema_from_result(result)
             self._cache_schema(schema, schema_id)
             return result

--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -100,6 +100,12 @@ class BaseClient:
     def __eq__(self, obj: typing.Any) -> bool:
         return self.conf == obj.conf and self.extra_headers == obj.extra_headers
 
+
+    @staticmethod
+    def _schema_from_result(result: dict) -> typing.Union[JsonSchema, AvroSchema]:
+        schema = result.get("schema")
+        schema_type = result.get("schemaType", utils.AVRO_SCHEMA_TYPE)
+
     def _configure_auth(self) -> typing.Tuple[str, str]:
         # Check first if the credentials are sent in Auth
         if self.auth is not None:
@@ -423,11 +429,7 @@ class SchemaRegistryClient(BaseClient):
             logger.info(f"Schema {schema_id} not found: {code}")
             return None
         elif status.is_success(code):
-            schema_str = result.get("schema")
-            schema_type = result.get("schemaType", utils.AVRO_SCHEMA_TYPE)
-
-            schema = SchemaFactory.create_schema(schema_str, schema_type)
-
+            schema = self._schema_from_result(result)
             self._cache_schema(schema, schema_id)
             return schema
 
@@ -508,7 +510,7 @@ class SchemaRegistryClient(BaseClient):
         if schema_id in self.id_to_schema:
             schema = self.id_to_schema[schema_id]
         else:
-            schema = AvroSchema(result["schema"])
+            schema = self._schema_from_result(result)
 
         version = result["version"]
         self._cache_schema(schema, schema_id, subject, version)
@@ -984,10 +986,8 @@ class AsyncSchemaRegistryClient(BaseClient):
             logger.info(f"Schema {schema_id} not found: {code}")
             return None
         elif status.is_success(code):
-            schema_str = result.get("schema")
-            result = AvroSchema(schema_str)
-
-            self._cache_schema(result, schema_id)
+            schema = self._schema_from_result(result)
+            self._cache_schema(schema, schema_id)
             return result
 
         raise ClientError(f"Received bad schema (id {schema_id})", http_code=code, server_traceback=result)
@@ -1038,7 +1038,9 @@ class AsyncSchemaRegistryClient(BaseClient):
         if schema_id in self.id_to_schema:
             schema = self.id_to_schema[schema_id]
         else:
-            schema = AvroSchema(result["schema"])
+            schema_str = result.get("schema")
+            schema_type = result.get("schemaType", utils.AVRO_SCHEMA_TYPE)
+            schema = SchemaFactory.create_schema(schema_str, schema_type)
 
         version = result["version"]
         self._cache_schema(schema, schema_id, subject, version)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             "isort",
             "pytest",
             "pytest-mock",
-            "pytest-asyncio",
+            "pytest-asyncio<0.19.0",
             "faker",
             "codecov",
             "pytest-cov",


### PR DESCRIPTION
## What this does

This fixes an issue where `AvroSchema` is assumed when getting a schema from the registry which is not already in the cached schemas.

In a few places `AvroSchema()` is being used directlly instead of inferring the schema type from the `schemaType` field of the response.

### To reproduce:
- Create a new schema registry client
- Add a JSON schema to the registry (without using the client)
- call `get_schema` or `get_by_id`

result: 
```
   File "/usr/local/lib/python3.9/site-packages/schema_registry/client/client.py", line 988, in get_by_id
     result = AvroSchema(schema_str)
   File "/usr/local/lib/python3.9/site-packages/schema_registry/client/schema.py", line 67, in __init__
     super().__init__(*args, **kwargs)
   File "/usr/local/lib/python3.9/site-packages/schema_registry/client/schema.py", line 20, in __init__
     self.schema = self.parse_schema(typing.cast(typing.Dict, schema))
   File "/usr/local/lib/python3.9/site-packages/schema_registry/client/schema.py", line 103, in parse_schema
     return fastavro.parse_schema(schema, _force=True)
   File "fastavro/_schema.pyx", line 103, in fastavro._schema.parse_schema
   File "fastavro/_schema.pyx", line 279, in fastavro._schema._parse_schema
 fastavro._schema_common.UnknownType: ... snip ...
```
The client attempts to create an AvroSchema from the JsonSchema input