### PR TITLE
fix location of py.typed marker, and include as package_data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Marcos Schroh",
     author_email="schrohm@gmail.com",
+    package_data={"schema_registry":["py.typed"]},
     install_requires=requires,
     extras_require={
         "faust": [


### PR DESCRIPTION
@marcosschroh , I apologize. I didn't fully vet the change for the py.typed marker earlier.
This PR moves the file to the schema_registry package and adds it to the package_data in setup.py. This ensures that the file will be available for type-checking when installed via pypi.
It has been verified locally and against a test-repostory on pypi,