### PR TITLE
Add support for generic httpx.Auth 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,19 @@ license = "MIT"
 readme = "README.md"
 packages = [{include = "schema_registry"}]
 
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development",
+]
+
 [tool.poetry.dependencies]
 python = "^3.7"
 fastavro = "^1.7.3"
@@ -44,19 +57,6 @@ faust = ["faust-streaming"]
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-classifiers = [
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3 :: Only",
-    "Topic :: Software Development",
-]
 
 [tool.black]
 line-length = 120

--- a/schema_registry/client/__init__.py
+++ b/schema_registry/client/__init__.py
@@ -1,5 +1,4 @@
 from . import errors, schema  # noqa
-from .auth_utils import Auth  # noqa
 from .client import AsyncSchemaRegistryClient, SchemaRegistryClient  # noqa
 
 __all__ = ["SchemaRegistryClient", "AsyncSchemaRegistryClient"]

--- a/schema_registry/client/auth_utils.py
+++ b/schema_registry/client/auth_utils.py
@@ -1,6 +1,0 @@
-from typing import NamedTuple
-
-
-class Auth(NamedTuple):
-    username: str
-    password: str

--- a/tests/client/async_client/test_http_client.py
+++ b/tests/client/async_client/test_http_client.py
@@ -136,6 +136,24 @@ async def test_auth():
     assert response.request.headers.get("Authorization") == f"Basic {token}"
 
 
+@pytest.mark.asyncio
+async def test_custom_auth():
+    class CustomAuth(httpx.Auth):
+        def __init__(self, token):
+            self.token = token
+
+        def auth_flow(self, request):
+            # Send the request, with a custom `X-Authentication` header.
+            request.headers["Authorization"] = f"Bearer {self.token}"
+            yield request
+
+    token = "token"
+    client = AsyncSchemaRegistryClient(url="https://@127.0.0.1:65534", auth=CustomAuth(token))
+
+    response = await client.request("https://example.com")
+    assert response.request.headers.get("Authorization") == f"Bearer {token}"
+
+
 def test_basic_auth_invalid():
     with pytest.raises(ValueError):
         AsyncSchemaRegistryClient(

--- a/tests/client/async_client/test_http_client.py
+++ b/tests/client/async_client/test_http_client.py
@@ -143,7 +143,7 @@ async def test_custom_auth():
             self.token = token
 
         def auth_flow(self, request):
-            # Send the request, with a custom `X-Authentication` header.
+            # Send the request, with a custom `Authorization` header.
             request.headers["Authorization"] = f"Bearer {self.token}"
             yield request
 

--- a/tests/client/async_client/test_http_client.py
+++ b/tests/client/async_client/test_http_client.py
@@ -5,7 +5,7 @@ from base64 import b64encode
 import httpx
 import pytest
 
-from schema_registry.client import AsyncSchemaRegistryClient, Auth, utils
+from schema_registry.client import AsyncSchemaRegistryClient, utils
 
 
 @pytest.mark.asyncio
@@ -127,7 +127,7 @@ async def test_auth():
     password = "secret"
     client = AsyncSchemaRegistryClient(
         url="https://user_url:secret_url@127.0.0.1:65534",
-        auth=Auth(username=username, password=password),
+        auth=httpx.BasicAuth(username=username, password=password),
     )
 
     userpass = b":".join((httpx._utils.to_bytes(username), httpx._utils.to_bytes(password)))

--- a/tests/client/sync_client/test_http_client.py
+++ b/tests/client/sync_client/test_http_client.py
@@ -5,7 +5,7 @@ import httpx
 import pytest
 from httpx import USE_CLIENT_DEFAULT
 
-from schema_registry.client import Auth, SchemaRegistryClient, schema, utils
+from schema_registry.client import SchemaRegistryClient, schema, utils
 from tests import data_gen
 
 
@@ -158,13 +158,23 @@ def test_auth():
     password = "secret"
     client = SchemaRegistryClient(
         url="https://user_url:secret_url@127.0.0.1:65534",
-        auth=Auth(username=username, password=password),
+        auth=httpx.BasicAuth(username=username, password=password),
     )
 
     userpass = b":".join((httpx._utils.to_bytes(username), httpx._utils.to_bytes(password)))
     token = b64encode(userpass).decode()
     response = client.request("https://example.com")
     assert response.request.headers.get("Authorization") == f"Basic {token}"
+
+
+def test_oauth():
+    def get_token():
+        return "token"
+
+    SchemaRegistryClient(
+        url="https://127.0.0.1:65534",
+        # oauth=OAuth2(token=partial(get_token)),
+    )
 
 
 def test_basic_auth_invalid():

--- a/tests/client/sync_client/test_http_client.py
+++ b/tests/client/sync_client/test_http_client.py
@@ -173,7 +173,7 @@ def test_custom_auth():
             self.token = token
 
         def auth_flow(self, request):
-            # Send the request, with a custom `X-Authentication` header.
+            # Send the request, with a custom `Authorization` header.
             request.headers["Authorization"] = f"Bearer {self.token}"
             yield request
 


### PR DESCRIPTION
Addresses #173 

This replaces the `schema_registry.auth_utils.Auth` class with `httpx.Auth`. This enables others to supply their own authentication logic in addition to `httpx.BasicAuth`

The current API/functionality of parsing the URL to determine the username/password has been maintained