### PR TITLE
remove print statement from serializer

### DIFF
--- a/schema_registry/serializers/message_serializer.py
+++ b/schema_registry/serializers/message_serializer.py
@@ -442,7 +442,6 @@ class AsyncMessageSerializer(ABC):
 
             try:
                 writer_schema = await self.schemaregistry_client.get_by_id(schema_id)
-                print(writer_schema, "holis...")
             except ClientError as e:
                 raise SerializerError(f"unable to fetch schema with id {schema_id}: {e}")
 


### PR DESCRIPTION
Was this print statement added on purpose? It causes a bit of noise in our logs. Would you consider removing it?