### PR TITLE
pin python version in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.11'
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
after PR #214 the publish workflow failed - https://github.com/marcosschroh/python-schema-registry-client/actions/runs/7071198746/job/19248657792

my guess was that it had something to do with running on python 3.12, and I was able to reproduce locally, so I pinned to python 3.11

```
↪ mkvirtualenv -p ~/.pyenv/versions/3.12.0/bin/python test312
...
(test312) ↪ poetry install --only ci-publish
...
  AttributeError: cython_sources


  at ~/Library/Application Support/pypoetry/venv/lib/python3.11/site-packages/poetry/installation/chef.py:147 in _prepare
      143│
      144│                 error = ChefBuildError("\n\n".join(message_parts))
      145│
      146│             if error is not None:
    → 147│                 raise error from None
      148│
      149│             return path
      150│
      151│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:

Note: This error originates from the build backend, and is likely not a problem with poetry but with pyyaml (6.0) not supporting PEP 517 builds. You can verify this by running 'pip wheel --use-pep517 "pyyaml (==6.0)"'.
```

but with 3.11
```
↪ mkvirtualenv -p ~/.pyenv/versions/3.11.5/bin/python test311
...
(test311) ↪ poetry install --only ci-publish
Installing dependencies from lock file

Package operations: 16 installs, 0 updates, 0 removals

  • Installing wcwidth (0.2.6)
  • Installing markupsafe (2.1.3)
  • Installing prompt-toolkit (3.0.38)
  • Installing zipp (3.15.0)
  • Installing argcomplete (3.1.1)
  • Installing charset-normalizer (3.1.0)
  • Installing colorama (0.4.6)
  • Installing decli (0.6.1)
  • Installing importlib-metadata (6.7.0)
  • Installing jinja2 (3.1.2)
  • Installing packaging (23.1)
  • Installing pyyaml (6.0)
  • Installing questionary (1.10.0)
  • Installing termcolor (2.3.0)
  • Installing tomlkit (0.11.8)
  • Installing commitizen (3.5.2)

Installing the current project: python-schema-registry-client (2.5.1)
```