### PR TITLE
fix order of arguments in SchemaVersion constructor

### DIFF
--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -524,7 +524,7 @@ class SchemaRegistryClient(BaseClient):
         version = result["version"]
         self._cache_schema(schema, schema_id, subject, version)
 
-        return utils.SchemaVersion(subject, schema_id, schema, version)
+        return utils.SchemaVersion(subject=subject, schema_id=schema_id, schema=schema, version=version)
 
     def get_versions(
         self,
@@ -632,7 +632,7 @@ class SchemaRegistryClient(BaseClient):
         schema_id = schemas_to_id.get(schema)
 
         if all((version, schema_id)):
-            return utils.SchemaVersion(subject, schema_id, version, schema)
+            return utils.SchemaVersion(subject=subject, schema_id=schema_id, version=version, schema=schema)
 
         url, method = self.url_manager.url_for("check_version", subject=subject)
         body = {"schema": json.dumps(schema.raw_schema), "schemaType": schema.schema_type}
@@ -647,7 +647,9 @@ class SchemaRegistryClient(BaseClient):
             version = result.get("version")
             self._cache_schema(schema, schema_id, subject, version)
 
-            return utils.SchemaVersion(subject, schema_id, version, result.get("schema"))
+            return utils.SchemaVersion(
+                subject=subject, schema_id=schema_id, version=version, schema=result.get("schema")
+            )
 
         raise ClientError("Unable to get version of a schema", http_code=code, server_traceback=result)
 
@@ -1043,7 +1045,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         version = result["version"]
         self._cache_schema(schema, schema_id, subject, version)
 
-        return utils.SchemaVersion(subject, schema_id, schema, version)
+        return utils.SchemaVersion(subject=subject, schema_id=schema_id, schema=schema, version=version)
 
     async def get_schema_subject_versions(
         self,
@@ -1190,7 +1192,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         schema_id = schemas_to_id.get(schema)
 
         if all((version, schema_id)):
-            return utils.SchemaVersion(subject, schema_id, version, schema)
+            return utils.SchemaVersion(subject=subject, schema_id=schema_id, version=version, schema=schema)
 
         url, method = self.url_manager.url_for("check_version", subject=subject)
         body = {"schema": json.dumps(schema.raw_schema), "schemaType": schema.schema_type}
@@ -1206,7 +1208,9 @@ class AsyncSchemaRegistryClient(BaseClient):
             version = result.get("version")
             self._cache_schema(schema, schema_id, subject, version)
 
-            return utils.SchemaVersion(subject, schema_id, version, result.get("schema"))
+            return utils.SchemaVersion(
+                subject=subject, schema_id=schema_id, version=version, schema=result.get("schema")
+            )
 
         raise ClientError("Unable to get version of a schema", http_code=code, server_traceback=result)
 

--- a/tests/client/async_client/test_schema_version.py
+++ b/tests/client/async_client/test_schema_version.py
@@ -30,6 +30,8 @@ async def test_avro_check_version(async_client, avro_country_schema):
 
     assert subject == result.subject
     assert schema_id == result.schema_id
+    assert isinstance(result.version, int)
+    assert isinstance(result.schema, str)
 
 
 @pytest.mark.asyncio

--- a/tests/client/sync_client/test_schema_version.py
+++ b/tests/client/sync_client/test_schema_version.py
@@ -24,6 +24,8 @@ def test_avro_check_version(client, avro_country_schema):
 
     assert subject == result.subject
     assert schema_id == result.schema_id
+    assert isinstance(result.version, int)
+    assert isinstance(result.schema, str)
 
 
 def test_avro_check_version_dataclasses_avroschema(client, dataclass_avro_schema):


### PR DESCRIPTION
Some calls to the SchemaVersion constructor swapped the order of the schema and version args. I switched them all to use kwargs to eliminate the problem.