### PR TITLE
Add verbose option for test_compatibility

### DIFF
--- a/schema_registry/client/client.py
+++ b/schema_registry/client/client.py
@@ -1253,7 +1253,7 @@ class AsyncSchemaRegistryClient(BaseClient):
         headers: typing.Optional[typing.Dict] = None,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         schema_type: typing.Literal["AVRO", "JSON"] = utils.AVRO_SCHEMA_TYPE,
-    ) -> typing.Union[bool, typing.Dict[str, typing.Any]]::
+    ) -> typing.Union[bool, typing.Dict[str, typing.Any]]:
         """Test the compatibility of a candidate parsed schema for a given subject.
 
         By default the latest version is checked against.

--- a/tests/client/sync_client/test_http_client.py
+++ b/tests/client/sync_client/test_http_client.py
@@ -85,6 +85,7 @@ def test_override_headers(client, avro_deployment_schema, mocker, response_klass
         "POST",
         mocker.ANY,
         headers=prepare_headers,
+        params=None,
         json=mocker.ANY,
         timeout=USE_CLIENT_DEFAULT,
     )

--- a/tests/client/sync_client/test_schema_compatibility.py
+++ b/tests/client/sync_client/test_schema_compatibility.py
@@ -78,7 +78,7 @@ def test_avro_compatibility_verbose(client, avro_user_schema_v3):
 
     compatibility = client.test_compatibility(subject, avro_user_schema_v3, verbose=True)
     assert isinstance(compatibility, dict)
-    assert compatibility["is_compatible"] is True 
+    assert compatibility["is_compatible"] is True
     assert isinstance(compatibility["messages"], list)
 
 

--- a/tests/client/sync_client/test_schema_compatibility.py
+++ b/tests/client/sync_client/test_schema_compatibility.py
@@ -12,7 +12,7 @@ def test_avro_compatibility(client, avro_user_schema_v3):
     client.register(subject, version_2)
 
     compatibility = client.test_compatibility(subject, avro_user_schema_v3)
-    assert compatibility
+    assert compatibility is True
 
 
 def test_avro_compatibility_dataclasses_avroschema(client, dataclass_avro_schema, dataclass_avro_schema_advance):
@@ -21,7 +21,7 @@ def test_avro_compatibility_dataclasses_avroschema(client, dataclass_avro_schema
     client.register(subject, dataclass_avro_schema.avro_schema())
 
     compatibility = client.test_compatibility(subject, dataclass_avro_schema_advance.avro_schema())
-    assert compatibility
+    assert compatibility is True
 
 
 def test_avro_update_compatibility_for_subject(client):
@@ -60,6 +60,28 @@ def test_avro_get_global_compatibility(client):
     assert client.get_compatibility() is not None
 
 
+def test_avro_compatibility_non_verbose(client, avro_user_schema_v3):
+    """Test the compatibility with the verbose option set to False"""
+    subject = "test-avro-user-schema"
+    version_2 = schema.AvroSchema(data_gen.AVRO_USER_V2)
+    client.register(subject, version_2)
+
+    compatibility = client.test_compatibility(subject, avro_user_schema_v3, verbose=False)
+    assert isinstance(compatibility, bool)
+
+
+def test_avro_compatibility_verbose(client, avro_user_schema_v3):
+    """Test the compatibility with the verbose option set to True"""
+    subject = "test-avro-user-schema"
+    version_2 = schema.AvroSchema(data_gen.AVRO_USER_V2)
+    client.register(subject, version_2)
+
+    compatibility = client.test_compatibility(subject, avro_user_schema_v3, verbose=True)
+    assert isinstance(compatibility, dict)
+    assert compatibility["is_compatible"] is True 
+    assert isinstance(compatibility["messages"], list)
+
+
 def test_json_compatibility(client, json_user_schema_v3):
     """Test the compatibility of a new User Schema against the User schema version 2."""
     subject = "test-json-user-schema"
@@ -68,7 +90,7 @@ def test_json_compatibility(client, json_user_schema_v3):
 
     compatibility = client.test_compatibility(subject, json_user_schema_v3)
 
-    assert compatibility
+    assert compatibility is True
 
 
 def test_json_compatibility_dataclasses_jsonschema(client, dataclass_json_schema, dataclass_json_schema_advance):
@@ -86,7 +108,7 @@ def test_json_compatibility_dataclasses_jsonschema(client, dataclass_json_schema
         schema_type=utils.JSON_SCHEMA_TYPE,
     )
 
-    assert compatibility
+    assert compatibility  is True
 
 
 def test_json_update_compatibility_for_subject(client):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,7 +132,7 @@ def response_klass():
     return Response
 
 
-RequestArgs = namedtuple("RequestArgs", ["url", "method", "body", "headers", "timeout"])
+RequestArgs = namedtuple("RequestArgs", ["url", "method", "body", "headers", "params", "timeout"])
 
 
 class Color(str, enum.Enum):
@@ -161,11 +161,12 @@ class RequestLoggingSchemaRegistryClient(SchemaRegistryClient, RequestLoggingAss
         url: str,
         method: str = "GET",
         body: dict = None,
+        params: dict = None,
         headers: dict = None,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> tuple:
-        self.request_calls.append(RequestArgs(url, method, body, headers, timeout))
-        return super().request(url, method, body, headers=headers, timeout=timeout)
+        self.request_calls.append(RequestArgs(url, method, body, headers, params, timeout))
+        return super().request(url, method, body, headers=headers, params=params, timeout=timeout)
 
 
 @pytest.fixture
@@ -323,11 +324,12 @@ class RequestLoggingAsyncSchemaRegistryClient(AsyncSchemaRegistryClient, Request
         url: str,
         method: str = "GET",
         body: dict = None,
+        params: dict = None,
         headers: dict = None,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
     ) -> tuple:
-        self.request_calls.append(RequestArgs(url, method, body, headers, timeout))
-        return await super().request(url, method, body, headers=headers, timeout=timeout)
+        self.request_calls.append(RequestArgs(url, method, body, headers, params, timeout))
+        return await super().request(url, method, body, headers=headers, params=params, timeout=timeout)
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
# Motivation

The schema-registry proposes a [`verbose` option][1] to retrieve the details, but that isn't available in this python client


# Proposed change

Add an option in the python client to retrieve the details in case of incompatiblity

- send the parameter `verbose` to the schema-registry API
- return the full JSON response if `verbose=True`


Closes https://github.com/marcosschroh/python-schema-registry-client/issues/337

[1]: https://docs.confluent.io/platform/current/schema-registry/develop/api.html#post--compatibility-subjects-(string-%20subject)-versions-(versionId-%20version)